### PR TITLE
feat: Add loading state to mutation buttons across various dialogs

### DIFF
--- a/src/components/feature-specific/company-bills/remove-bill-action-dialog.tsx
+++ b/src/components/feature-specific/company-bills/remove-bill-action-dialog.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogFooter,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
@@ -23,7 +23,7 @@ export default function ({ bill }: Props) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
-  const { mutate: removeExitBillMutation } = useMutation({
+  const { mutate: removeExitBillMutation, isPending } = useMutation({
     mutationFn: removeExitBill,
     onSuccess: () => {
       toast({
@@ -58,6 +58,7 @@ export default function ({ bill }: Props) {
           <Button
             variant="destructive"
             onClick={() => removeExitBillMutation(bill.ID)}
+            disabled={isPending}
           >
             Remove
           </Button>

--- a/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-entry-bills-form.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-entry-bills-form.tsx
@@ -54,7 +54,7 @@ export default function ({ bill }: Props) {
     enabled: !!franchise,
   });
   const queryClient = useQueryClient();
-  const { mutate: createEntryBillMutation } = useMutation({
+  const { mutate: createEntryBillMutation, isPending } = useMutation({
     mutationFn: createFranchiseEntryBill,
     onSuccess: () => {
       toast({
@@ -189,6 +189,7 @@ export default function ({ bill }: Props) {
             Cancel
           </Button>
           <Button
+            disabled={isPending}
             onClick={() => {
               form.setValue(
                 "bill_items",

--- a/src/components/feature-specific/company-franchises/franchise-card.tsx
+++ b/src/components/feature-specific/company-franchises/franchise-card.tsx
@@ -27,7 +27,7 @@ export default function ({ franchise }: Props) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { mutate: deleteFranchiseMutation } = useMutation({
+  const { mutate: deleteFranchiseMutation, isPending } = useMutation({
     mutationFn: deleteFranchise,
     onSuccess: () => {
       toast({
@@ -68,6 +68,7 @@ export default function ({ franchise }: Props) {
             </DialogHeader>
             <DialogFooter>
               <Button
+                disabled={isPending}
                 variant={"destructive"}
                 onClick={() => deleteFranchiseMutation(franchise.ID)}
               >

--- a/src/components/feature-specific/company-products/print-products-labels-dialog.tsx
+++ b/src/components/feature-specific/company-products/print-products-labels-dialog.tsx
@@ -53,7 +53,7 @@ export default function () {
     queryFn: () => getCompanyInventory(company?.ID ?? 0),
   });
   const { toast } = useToast();
-  const { mutate: generateBarcodesMutation } = useMutation({
+  const { mutate: generateBarcodesMutation, isPending } = useMutation({
     mutationFn: generateBarcodes,
     onSuccess: () => {
       setIsOpen(false);
@@ -149,7 +149,10 @@ export default function () {
         </ScrollArea>
         <DialogFooter>
           <Button variant={"outline"}>Cancel</Button>
-          <Button onClick={form.handleSubmit(onSaveClicked, console.error)}>
+          <Button
+            disabled={isPending}
+            onClick={form.handleSubmit(onSaveClicked, console.error)}
+          >
             Save
           </Button>
         </DialogFooter>

--- a/src/components/feature-specific/company-products/update-product-form.tsx
+++ b/src/components/feature-specific/company-products/update-product-form.tsx
@@ -1,19 +1,19 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -43,7 +43,7 @@ export default function MyForm({ product }: Props) {
   });
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const { mutate: updateProductMutation } = useMutation({
+  const { mutate: updateProductMutation, isPending } = useMutation({
     mutationFn: (data: UpdateProductSchema) => updateProduct(product.ID, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["products"] });
@@ -189,7 +189,9 @@ export default function MyForm({ product }: Props) {
           <Button onClick={() => setOpen(false)} variant={"outline"}>
             Cancel
           </Button>
-          <Button onClick={form.handleSubmit(onSubmit)}>Save</Button>
+          <Button disabled={isPending} onClick={form.handleSubmit(onSubmit)}>
+            Save
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/feature-specific/company-sales/add-company-sale-dialog.tsx
+++ b/src/components/feature-specific/company-sales/add-company-sale-dialog.tsx
@@ -139,7 +139,7 @@ export default function () {
     );
   }
   const queryClient = useQueryClient();
-  const { mutate: createCompanySaleMutation } = useMutation({
+  const { mutate: createCompanySaleMutation, isPending } = useMutation({
     mutationFn: createCompanySale,
     onSuccess: () => {
       setOpen(false);
@@ -330,7 +330,12 @@ export default function () {
           <Button variant="outline" onClick={() => setOpen(false)}>
             Close
           </Button>
-          <Button onClick={form.handleSubmit(handleCreateSale)}>Save</Button>
+          <Button
+            disabled={isPending}
+            onClick={form.handleSubmit(handleCreateSale)}
+          >
+            Save
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/feature-specific/company-supplier/remove-supplier-bill-dialog.tsx
+++ b/src/components/feature-specific/company-supplier/remove-supplier-bill-dialog.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogFooter,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { SupplierBill } from "@/models/data/supplier.model";
@@ -19,7 +19,7 @@ export default function ({ bill }: Props) {
   const [open, setOpen] = useState(false);
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { mutate: deleteSupplierBillMutation } = useMutation({
+  const { mutate: deleteSupplierBillMutation , isPending} = useMutation({
     mutationFn: deleteSupplierBill,
     onSuccess: () => {
       toast({
@@ -50,6 +50,7 @@ export default function ({ bill }: Props) {
         <div>Are you sure you want to remove this bill ?</div>
         <DialogFooter>
           <Button
+            disabled={isPending}
             variant={"destructive"}
             onClick={() => deleteSupplierBillMutation(bill.ID)}
           >

--- a/src/components/feature-specific/company-suppliers/add-supplier-dialog.tsx
+++ b/src/components/feature-specific/company-suppliers/add-supplier-dialog.tsx
@@ -1,21 +1,21 @@
 import { RootState } from "@/app/store";
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
@@ -43,7 +43,7 @@ export default function () {
   });
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const { mutate: createSupplierMutation } = useMutation({
+  const { mutate: createSupplierMutation, isPending } = useMutation({
     mutationFn: createSupplier,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["suppliers"] });
@@ -127,7 +127,7 @@ export default function () {
         </Form>
         <DialogFooter>
           <Button variant={"outline"}>Cancel</Button>
-          <Button onClick={form.handleSubmit(onSaveClicked, console.error)}>
+          <Button disabled={isPending} onClick={form.handleSubmit(onSaveClicked, console.error)}>
             Add
           </Button>
         </DialogFooter>

--- a/src/components/feature-specific/company-suppliers/supplier-remove-dialog.tsx
+++ b/src/components/feature-specific/company-suppliers/supplier-remove-dialog.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { Supplier } from "@/models/data/supplier.model";
@@ -23,7 +23,7 @@ export default function ({ supplier }: Props) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const { toast } = useToast();
-  const { mutate: removeSupplierMutation } = useMutation({
+  const { mutate: removeSupplierMutation, isPending } = useMutation({
     mutationFn: removeSupplier,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["suppliers"] });
@@ -61,6 +61,7 @@ export default function ({ supplier }: Props) {
         <DialogFooter>
           <Button onClick={()=> setOpen(false)} variant={"outline"}>Cancel</Button>
           <Button
+            disabled={isPending}
             variant={"destructive"}
             onClick={() => {
               removeSupplierMutation(supplier.ID);

--- a/src/components/feature-specific/company/delete-company-dialog.tsx
+++ b/src/components/feature-specific/company/delete-company-dialog.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { Company } from "@/models/data/company.model";
@@ -23,7 +23,7 @@ export default function ({ company }: Props) {
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const { mutate: deleteComapnyMutation } = useMutation({
+  const { mutate: deleteComapnyMutation, isPending } = useMutation({
     mutationFn: deleteCompany,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["companies"] });
@@ -66,6 +66,7 @@ export default function ({ company }: Props) {
             Cancel
           </Button>
           <Button
+            disabled={isPending}
             onClick={() => deleteComapnyMutation(company.ID)}
             variant={"destructive"}
           >

--- a/src/components/feature-specific/franchise-auth/franchise-auth-login-form.tsx
+++ b/src/components/feature-specific/franchise-auth/franchise-auth-login-form.tsx
@@ -1,19 +1,19 @@
 import { useAppDispatch } from "@/app/hooks";
 import { Button } from "@/components/ui/button";
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardFooter,
-    CardTitle,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardTitle,
 } from "@/components/ui/card";
 import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { login } from "@/features/auth/franchise-slice";
@@ -33,7 +33,7 @@ export default function () {
   const { toast } = useToast();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const { mutate: loginMutate } = useMutation({
+  const { mutate: loginMutate , isPending } = useMutation({
     mutationFn: loginMyFranchise,
     onSuccess: (data) => {
       toast({
@@ -99,7 +99,7 @@ export default function () {
       </CardContent>
       <CardFooter className="flex justify-end gap-2">
         <Button variant={"outline"}>Request Access</Button>
-        <Button onClick={form.handleSubmit((data) => loginMutate(data))}>
+        <Button disabled={isPending} onClick={form.handleSubmit((data) => loginMutate(data))}>
           <Key />
           Login
         </Button>

--- a/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-entry-bills-form.tsx
+++ b/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-entry-bills-form.tsx
@@ -54,7 +54,7 @@ export default function ({ bill }: Props) {
     enabled: !!franchise,
   });
   const queryClient = useQueryClient();
-  const { mutate: createEntryBillMutation } = useMutation({
+  const { mutate: createEntryBillMutation , isPending } = useMutation({
     mutationFn: createFranchiseEntryBill,
     onSuccess: () => {
       toast({
@@ -189,6 +189,7 @@ export default function ({ bill }: Props) {
             Cancel
           </Button>
           <Button
+            disabled={isPending}
             onClick={() => {
               form.setValue(
                 "bill_items",


### PR DESCRIPTION
- Enhanced user experience by disabling action buttons during pending mutation states in the following components:
  - `delete-company-dialog`
  - `remove-bill-action-dialog`
  - `franchise-entry-bills-form`
  - `franchise-card`
  - `print-products-labels-dialog`
  - `update-product-form`
  - `add-company-sale-dialog`
  - `remove-supplier-bill-dialog`
  - `add-supplier-dialog`
  - `supplier-remove-dialog`
  - `franchise-auth-login-form`

These changes prevent multiple submissions and improve the overall usability of the dialogs.