### PR TITLE
feat: Implement scrollable areas in bill dialogs for better usability

### DIFF
--- a/src/components/feature-specific/company-bills/company-bill-dialog.tsx
+++ b/src/components/feature-specific/company-bills/company-bill-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { ExitBill } from "@/models/data/bill.model";
 import { CircleX, LucideTicket, Printer } from "lucide-react";
 import { useState } from "react";
@@ -40,7 +41,7 @@ export default function ({ bill }: Props) {
             <span className="font-bold">Date:</span>
             <p className="text-white font-bold">{new Date(bill.franchise?.CreatedAt ?? "").toDateString()}</p>
           </div>
-          <div>
+          <ScrollArea className="max-h-[400px]">
             {bill.bill_items.map((billItem) => (
               <div key={`bill-item-${billItem.id}`} className="flex justify-between">
                 <span className="text-white">
@@ -51,7 +52,7 @@ export default function ({ bill }: Props) {
                 <span className="text-bold">Qty: {billItem.quantity}</span>
               </div>
             ))}
-          </div>
+          </ScrollArea>
           <div></div>
           <div>
             <div className="flex justify-between">

--- a/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-exit-bill-dialog.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-exit-bill-dialog.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { ExitBill } from "@/models/data/bill.model";
 import { CircleX, LucideTicket, Printer } from "lucide-react";
 import { useState } from "react";
@@ -42,7 +43,7 @@ export default function ({ bill }: Props) {
               {new Date(bill.franchise?.CreatedAt ?? "").toDateString()}
             </p>
           </div>
-          <div>
+          <ScrollArea className="max-h-[400px]">
             {bill.bill_items.map((billItem) => (
               <div
                 key={`bill-item-${billItem.id}`}
@@ -56,7 +57,7 @@ export default function ({ bill }: Props) {
                 <span className="text-bold">Qty: {billItem.quantity}</span>
               </div>
             ))}
-          </div>
+          </ScrollArea>
           <div></div>
           <div>
             <div className="flex justify-between">

--- a/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-extra-entry-bill-dialog.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-extra-entry-bill-dialog.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { BillItem, EntryBill } from "@/models/data/bill.model";
 import { APIResponse } from "@/models/responses/api-response.model";
 import { CreateEntryBillSchema } from "@/schemas/bill";
@@ -56,14 +57,14 @@ export default function ({
             bill.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-2">
+        <ScrollArea className="flex flex-col gap-2 max-h-[400px]">
           {extraItems.map((item) => (
             <div key={item.product_variant_id} className="flex justify-between">
               <span className="text-white">{item.qr_code}</span>
               <span className="text-bold">Qty: {item.quantity}</span>
             </div>
           ))}
-        </div>
+        </ScrollArea>
         <DialogFooter>
           <Button
             variant={"outline"}

--- a/src/components/feature-specific/company-franchises/make-bill-dialog.tsx
+++ b/src/components/feature-specific/company-franchises/make-bill-dialog.tsx
@@ -16,6 +16,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
 import { BillItem } from "@/models/data/bill.model";
 import { Franchise } from "@/models/data/franchise.model";
@@ -74,7 +75,6 @@ export default function ({ franchise }: Props) {
     queryFn: () => getCompanyInventory(company?.ID ?? 0),
   });
 
-
   const handleCreateExitBill = (data: CreateExitBillSchema) => {
     createExitBillMutation({
       ...data,
@@ -84,8 +84,9 @@ export default function ({ franchise }: Props) {
       })),
     });
   };
-  const barcodes:string[] =
-  inventory?.data?.items.map((item) => item.product_variant?.qr_code ?? "") ?? [];
+  const barcodes: string[] =
+    inventory?.data?.items.map((item) => item.product_variant?.qr_code ?? "") ??
+    [];
   const myProcessBarcode = () =>
     processBarcode({
       inventory: inventory!,
@@ -159,7 +160,7 @@ export default function ({ franchise }: Props) {
             autoFocus
           />
           <div>
-            <ul className="flex flex-col gap-2 p-2">
+            <ScrollArea className="flex flex-col gap-2 p-2 max-h-[400px]">
               {billItems.map((billItem) => (
                 <MakeBillTile
                   key={billItem.product_variant_id}
@@ -169,7 +170,7 @@ export default function ({ franchise }: Props) {
                   items={inventory?.data?.items ?? []}
                 />
               ))}
-            </ul>
+            </ScrollArea>
           </div>
           <div className="flex text-xl text-white justify-end">
             Total:{" "}

--- a/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-entry-bills-form.tsx
+++ b/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-entry-bills-form.tsx
@@ -9,6 +9,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
 import { BillItem, ExitBill } from "@/models/data/bill.model";
 import { CreateEntryBillSchema, createEntryBillSchema } from "@/schemas/bill";
@@ -164,7 +165,7 @@ export default function ({ bill }: Props) {
               autoFocus
             />
             <div>
-              <ul className="flex flex-col gap-2 p-2">
+              <ScrollArea className="flex flex-col gap-2 p-2 max-h-[400px]">
                 {billItems.map((billItem) => (
                   <MakeBillTile
                     key={billItem.product_variant_id}
@@ -174,7 +175,7 @@ export default function ({ bill }: Props) {
                     items={inventory?.data?.items ?? []}
                   />
                 ))}
-              </ul>
+              </ScrollArea>
             </div>
           </div>
         </DialogHeader>

--- a/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-exit-bill-dialog.tsx
+++ b/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-exit-bill-dialog.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { ExitBill } from "@/models/data/bill.model";
 import { CircleX, LucideTicket, Printer } from "lucide-react";
 import { useState } from "react";
@@ -42,7 +43,7 @@ export default function ({ bill }: Props) {
               {new Date(bill.franchise?.CreatedAt ?? "").toDateString()}
             </p>
           </div>
-          <div>
+          <ScrollArea className="max-h-[400px]">
             {bill.bill_items.map((billItem) => (
               <div
                 key={`bill-item-${billItem.id}`}
@@ -56,7 +57,7 @@ export default function ({ bill }: Props) {
                 <span className="text-bold">Qty: {billItem.quantity}</span>
               </div>
             ))}
-          </div>
+          </ScrollArea>
           <div></div>
           <div>
             <div className="flex justify-between">

--- a/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-extra-entry-bill-dialog.tsx
+++ b/src/components/feature-specific/franchise-bills/franchise-bills-tabs/franchise-extra-entry-bill-dialog.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { BillItem, EntryBill } from "@/models/data/bill.model";
 import { APIResponse } from "@/models/responses/api-response.model";
 import { CreateEntryBillSchema } from "@/schemas/bill";
@@ -56,14 +57,14 @@ export default function ({
             bill.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-2">
+        <ScrollArea className="flex flex-col gap-2 max-h-[400px]">
           {extraItems.map((item) => (
             <div key={item.product_variant_id} className="flex justify-between">
               <span className="text-white">{item.qr_code}</span>
               <span className="text-bold">Qty: {item.quantity}</span>
             </div>
           ))}
-        </div>
+        </ScrollArea>
         <DialogFooter>
           <Button
             variant={"outline"}


### PR DESCRIPTION
- Added `ScrollArea` component to various bill-related dialogs, including:
  - `company-bill-dialog`
  - `franchise-exit-bill-dialog`
  - `franchise-extra-entry-bill-dialog`
  - `make-bill-dialog`
  - `franchise-entry-bills-form`

These changes enhance the user experience by allowing users to scroll through bill items in a constrained space, improving accessibility and readability for larger lists.