### PR TITLE
feat(unknown-returns): Add functionality for managing unknown returns

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -20,6 +20,7 @@ import CompanyProductsPage from "@/pages/dashboard/company/company-products-page
 import CompanySalesPage from "@/pages/dashboard/company/company-sales-page";
 import CompanySupplierPage from "@/pages/dashboard/company/company-supplier-page";
 import CompanySuppliersPage from "@/pages/dashboard/company/company-suppliers-page";
+import CompanyUnknownReturnsPage from "@/pages/dashboard/company/company-unknown-returns-page";
 import WarehousePage from "@/pages/dashboard/company/warehouse-page";
 import DashboardPage from "@/pages/dashboard/dashboard-page";
 import MenuPage from "@/pages/dashboard/menu-page";
@@ -82,6 +83,10 @@ export default function AppRouter() {
               <Route
                 path="suppliers/:supplierID"
                 element={<CompanySupplierPage />}
+              />
+              <Route
+                path="unknown-returns"
+                element={<CompanyUnknownReturnsPage />}
               />
             </Route>
           </Route>

--- a/src/components/feature-specific/company-unknown-returns/add-company-unknown-return-dialog.tsx
+++ b/src/components/feature-specific/company-unknown-returns/add-company-unknown-return-dialog.tsx
@@ -1,0 +1,254 @@
+import { RootState } from "@/app/store";
+import { ProductVariantCombobox } from "@/components/feature-specific/company-products/product-variant-combobox";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import {
+    createUnknownReturnSchema,
+    CreateUnknownReturnSchema,
+} from "@/schemas/return-schema";
+import { getCompanyInventory } from "@/services/inventory-service";
+import { createCompanyUnknownReturn } from "@/services/return-service";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, X } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useSelector } from "react-redux";
+
+export default function () {
+  const [isOpen, setIsOpen] = useState(false);
+  const company = useSelector((state: RootState) => state.company.company);
+  const form = useForm<CreateUnknownReturnSchema>({
+    resolver: zodResolver(createUnknownReturnSchema),
+    defaultValues: {
+      return_items: [],
+      cost: 0,
+      location_id: company?.ID ?? 0,
+    },
+  });
+  const { data: inventory } = useQuery({
+    queryKey: ["products-variants"],
+    queryFn: () => getCompanyInventory(company?.ID ?? 0),
+  });
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { mutate: createUnknownReturn, isPending } = useMutation({
+    mutationFn: createCompanyUnknownReturn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["company-unknown-returns"],
+      });
+      toast({
+        title: "Return created",
+        description: "Return created successfully",
+      });
+      setIsOpen(false);
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus />
+          Unknown Return
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Unknown Return</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <>
+            <Button
+              onClick={() => {
+                form.setValue("return_items", [
+                  {
+                    product_variant_id: 0,
+                    quantity: 1,
+                  },
+                  ...form.watch("return_items"),
+                ]);
+              }}
+            >
+              <Plus /> Add Product
+            </Button>
+            <ScrollArea className="max-h-[400px]">
+              <Table>
+                <TableHeader>
+                  <TableHead>Product</TableHead>
+                  <TableHead>Qty</TableHead>
+                </TableHeader>
+                <TableBody>
+                  {form.watch("return_items").map((_, i) => (
+                    <TableRow key={i}>
+                      <TableCell>
+                        <FormField
+                          name={`return_items.${i}.product_variant_id`}
+                          control={form.control}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormControl>
+                                <ProductVariantCombobox
+                                  variants={
+                                    inventory?.data?.items.map(
+                                      (item) => item.product_variant!
+                                    ) ?? []
+                                  }
+                                  value={field.value}
+                                  onChange={field.onChange}
+                                  placeholder="Select a variant..."
+                                  disabled={field.disabled}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <FormField
+                          name={`return_items.${i}.quantity`}
+                          control={form.control}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormControl>
+                                <Input
+                                  {...field}
+                                  type="number"
+                                  onChange={(e) => {
+                                    field.onChange(
+                                      parseInt(e.target.value) ?? 0
+                                    );
+                                  }}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <Button
+                          variant={"ghost"}
+                          onClick={() =>
+                            form.setValue(
+                              "return_items",
+                              form
+                                .watch("return_items")
+                                .filter((_, idx) => idx !== i)
+                            )
+                          }
+                        >
+                          <X />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          </>
+          <FormField
+            name={`cost`}
+            control={form.control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Cost</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    type="number"
+                    onChange={(e) => {
+                      field.onChange(parseInt(e.target.value) ?? 0);
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </Form>
+        {/* Card of Totals */}
+        <div className="flex justify-end">
+          <div className="flex flex-col gap-2">
+            <div className="flex justify-between gap-2">
+              <p>Amount:</p>
+              <p>
+                {form.watch("return_items").reduce((acc, item) => {
+                  const variant = inventory?.data?.items.find(
+                    (i) => i.product_variant?.ID === item.product_variant_id
+                  );
+                  if (!variant) return acc;
+                  return acc + (variant.product?.price ?? 0) * item.quantity;
+                }, 0)}
+              </p>
+            </div>
+            <div className="flex justify-between">
+              <p>Total</p>
+              <p>
+                {form.watch("return_items").reduce((acc, item) => {
+                  const variant = inventory?.data?.items.find(
+                    (i) => i.product_variant?.ID === item.product_variant_id
+                  );
+                  if (!variant) return acc;
+                  return acc + (variant.product?.price ?? 0) * item.quantity;
+                }, 0) + form.watch("cost")}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant={"outline"} onClick={() => setIsOpen(false)}>
+            Close
+          </Button>
+          <Button
+            disabled={isPending}
+            onClick={form.handleSubmit((data) => {
+              createUnknownReturn(data);
+            }, console.error)}
+            type="submit"
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature-specific/company-unknown-returns/company-unknown-returns-app-bar.tsx
+++ b/src/components/feature-specific/company-unknown-returns/company-unknown-returns-app-bar.tsx
@@ -1,0 +1,20 @@
+import { RootState } from "@/app/store";
+import AppBarBackButton from "@/components/common/app-bar-back-button";
+import AddCompanyUnknownReturnDialog from "@/components/feature-specific/company-unknown-returns/add-company-unknown-return-dialog";
+import { useSelector } from "react-redux";
+
+export default function () {
+  const company = useSelector((state: RootState) => state.company.company);
+  if (!company) return;
+  return (
+    <div className="flex justify-between">
+      <div className="flex gap-4 items-center">
+        <AppBarBackButton destination="Menu" />
+        <span className="text-2xl font-bold">
+          {company.company_name} &gt; Unknown Returns
+        </span>
+      </div>
+      <AddCompanyUnknownReturnDialog />
+    </div>
+  );
+}

--- a/src/components/feature-specific/company-unknown-returns/company-unknown-returns-columns.tsx
+++ b/src/components/feature-specific/company-unknown-returns/company-unknown-returns-columns.tsx
@@ -1,0 +1,27 @@
+import CompanyUnknwonReturnsActionsDropdown from "@/components/feature-specific/company-unknown-returns/company-unknwon-returns-actions-dropdown";
+import { Return } from "@/models/data/return.model";
+import { ColumnDef } from "@tanstack/react-table";
+
+export const companyUnknownReturnsColumns: ColumnDef<Return>[] = [
+  {
+    accessorKey: "ID",
+    id: "id",
+    header: "ID",
+  },
+  {
+    accessorKey: "CreatedAt",
+    header: "Created At",
+  },
+  {
+    accessorKey: "cost",
+    header: "Cost",
+  },
+  {
+    accessorKey: "total",
+    header: "Total",
+  },
+  {
+    header: "Actions",
+    cell: ({row}) => <CompanyUnknwonReturnsActionsDropdown returnModel={row.original} />
+  }
+];

--- a/src/components/feature-specific/company-unknown-returns/company-unknown-returns-table.tsx
+++ b/src/components/feature-specific/company-unknown-returns/company-unknown-returns-table.tsx
@@ -1,0 +1,23 @@
+import { RootState } from "@/app/store";
+import { companyUnknownReturnsColumns } from "@/components/feature-specific/company-unknown-returns/company-unknown-returns-columns";
+import { DataTable } from "@/components/ui/data-table";
+import { getCompanyUnknownReturns } from "@/services/return-service";
+import { useQuery } from "@tanstack/react-query";
+import { useSelector } from "react-redux";
+
+export default function () {
+  const company = useSelector((state: RootState) => state.company.company);
+  const { data } = useQuery({
+    queryKey: ["company-unknown-returns"],
+    queryFn: () => getCompanyUnknownReturns(company?.ID ?? 0),
+  });
+  return (
+    <div>
+      <DataTable
+        searchColumn="id"
+        data={data?.data ?? []}
+        columns={companyUnknownReturnsColumns}
+      />
+    </div>
+  );
+}

--- a/src/components/feature-specific/company-unknown-returns/company-unknwon-returns-actions-dropdown.tsx
+++ b/src/components/feature-specific/company-unknown-returns/company-unknwon-returns-actions-dropdown.tsx
@@ -1,0 +1,38 @@
+import RemoveReturnDialog from "@/components/feature-specific/company-unknown-returns/remove-return-dialog";
+import ViewReturnDetailsDialog from "@/components/feature-specific/company-unknown-returns/view-return-details-dialog";
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Return } from "@/models/data/return.model";
+import { MoreHorizontal } from "lucide-react";
+
+interface Props {
+  returnModel: Return;
+}
+
+export default function ({ returnModel }: Props) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger>
+        <Button variant={"ghost"}>
+          <MoreHorizontal />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          onClick={() =>
+            navigator.clipboard.writeText(returnModel.ID.toString())
+          }
+        >
+          Copy return ID
+        </DropdownMenuItem>
+        <ViewReturnDetailsDialog returnModel={returnModel} />
+        <RemoveReturnDialog returnModel={returnModel} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/feature-specific/company-unknown-returns/remove-return-dialog.tsx
+++ b/src/components/feature-specific/company-unknown-returns/remove-return-dialog.tsx
@@ -1,0 +1,83 @@
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { useToast } from "@/hooks/use-toast";
+import { Return } from "@/models/data/return.model";
+import { removeCompanyUnknownReturn } from "@/services/return-service";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+
+interface Props {
+  returnModel: Return;
+}
+
+export default function ({ returnModel }: Props) {
+  const [open, setOpen] = useState(false);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { mutate: removeReturn, isPending } = useMutation({
+    mutationFn: () => removeCompanyUnknownReturn(returnModel.ID),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["company-unknown-returns"],
+      });
+      toast({
+        title: "Return removed",
+        description: "Return removed successfully",
+      });
+      setOpen(false);
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <DropdownMenuItem
+          className="text-red-600"
+          onSelect={(e) => e.preventDefault()}
+        >
+          <Trash2 className="mr-2 h-4 w-4" />
+          Remove Return
+        </DropdownMenuItem>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Remove Return</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to remove return #{returnModel.ID}? This
+            action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogTrigger asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogTrigger>
+          <Button
+            variant="destructive"
+            onClick={() => removeReturn()}
+            disabled={isPending}
+          >
+            Remove Return
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature-specific/company-unknown-returns/view-return-details-dialog.tsx
+++ b/src/components/feature-specific/company-unknown-returns/view-return-details-dialog.tsx
@@ -1,0 +1,115 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+    Table,
+    TableBody,
+    TableHead,
+    TableHeader,
+} from "@/components/ui/table";
+import { Return } from "@/models/data/return.model";
+import { Search } from "lucide-react";
+
+interface Props {
+  returnModel: Return;
+}
+
+export default function ({ returnModel }: Props) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+          <Search />
+          View Return Details
+        </DropdownMenuItem>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Return Details</DialogTitle>
+          <DialogDescription>
+            View details for return #{returnModel.ID}
+            <br />
+            Created at: {new Date(returnModel.CreatedAt).toLocaleDateString()}
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="max-h-[300px]">
+          <Table className="w-full">
+            <TableHeader>
+              <TableHead>Item</TableHead>
+              <TableHead>Quantity</TableHead>
+              <TableHead>Unit Price</TableHead>
+              <TableHead>Total</TableHead>
+            </TableHeader>
+            <TableBody>
+              {returnModel.items.map((item, index) => (
+                <tr key={index} className="border-b">
+                  <td className="p-4">{item.product_variant?.qr_code}</td>
+                  <td className="p-4">{item.quantity}</td>
+                  <td className="p-4">
+                    {new Intl.NumberFormat("en-DZ", {
+                      style: "currency",
+                      currency: "DZD",
+                    }).format(item.product_variant?.product?.price ?? 0)}
+                  </td>
+                  <td className="p-4">
+                    {new Intl.NumberFormat("en-DZ", {
+                      style: "currency",
+                      currency: "DZD",
+                    }).format(
+                      item.quantity *
+                        (item.product_variant?.product?.price ?? 0)
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </TableBody>
+          </Table>
+        </ScrollArea>
+
+        <Card className="mt-4">
+          <CardContent>
+            <dl className="divide-y">
+              {[
+                {
+                  label: "Cost",
+                  value: new Intl.NumberFormat("en-DZ", {
+                    style: "currency",
+                    currency: "DZD",
+                  }).format(returnModel.cost),
+                },
+                {
+                  label: "Total",
+                  value: new Intl.NumberFormat("en-DZ", {
+                    style: "currency",
+                    currency: "DZD",
+                  }).format(returnModel.total),
+                },
+              ].map(({ label, value }) => (
+                <div key={label} className="flex gap-2 py-3">
+                  <dt className="">{label}</dt>
+                  <dd className="font-bold">{value}</dd>
+                </div>
+              ))}
+            </dl>
+          </CardContent>
+        </Card>
+
+        <DialogFooter>
+          <DialogTrigger asChild>
+            <Button variant="outline">Close</Button>
+          </DialogTrigger>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/models/data/return.model.ts
+++ b/src/models/data/return.model.ts
@@ -1,3 +1,5 @@
+import { Company } from "@/models/data/company.model";
+import { Franchise } from "@/models/data/franchise.model";
 import { ProductVariant } from "./product.model";
 import { Sale } from "./sale.model";
 
@@ -8,8 +10,13 @@ export interface Return {
     DeletedAt: string | null;
     sale_id: number | null;
     order_id: number | null;
+    company_id: number | null;
+    franchise_id: number | null;
+
     sale: Sale | null;
     // order: Order | null;
+    company: Company | null;
+    franchise: Franchise | null;
     reason: string;
     type: string;
     comment: string;

--- a/src/pages/dashboard/company/company-control-panel-page.tsx
+++ b/src/pages/dashboard/company/company-control-panel-page.tsx
@@ -2,12 +2,21 @@ import { RootState } from "@/app/store";
 import WideButton from "@/components/common/wide-button";
 import CompanyTile from "@/components/feature-specific/company/company-tile";
 import { Button } from "@/components/ui/button";
-import { Apple, ArrowLeft, Handshake, ReceiptText, ShoppingCart, Store, Warehouse } from "lucide-react";
+import {
+  Apple,
+  ArrowLeft,
+  Handshake,
+  ReceiptText,
+  ShoppingCart,
+  Store,
+  Undo2,
+  Warehouse,
+} from "lucide-react";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
 export default function () {
-  const {pathname} = useLocation();
+  const { pathname } = useLocation();
   const navigate = useNavigate();
   const lastLocation = pathname.substring(0, pathname.lastIndexOf("/"));
   const company = useSelector((state: RootState) => state.company.company);
@@ -65,5 +74,9 @@ const quickMenu = [
     icon: Handshake,
     href: "suppliers",
   },
-
+  {
+    label: "Unkown Returns",
+    icon: Undo2,
+    href: "unknown-returns",
+  },
 ];

--- a/src/pages/dashboard/company/company-unknown-returns-page.tsx
+++ b/src/pages/dashboard/company/company-unknown-returns-page.tsx
@@ -1,0 +1,11 @@
+import CompanyUnknownReturnsAppBar from "@/components/feature-specific/company-unknown-returns/company-unknown-returns-app-bar";
+import CompanyUnknownReturnsTable from "@/components/feature-specific/company-unknown-returns/company-unknown-returns-table";
+
+export default function () {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <CompanyUnknownReturnsAppBar />
+      <CompanyUnknownReturnsTable />
+    </div>
+  );
+}

--- a/src/schemas/return-schema.ts
+++ b/src/schemas/return-schema.ts
@@ -76,3 +76,25 @@ export const makeCreateSaleReturnSchema = (sale: Sale) => z.object({
 });
 
 export type CreateSaleReturnSchema = z.infer<typeof createSaleReturnSchema>;
+
+
+export const createUnknownReturnSchema = z.object({
+    return_items: z.array(z.object({
+        product_variant_id: z.number().min(1, "Please insert a product"),
+        quantity: z.number().min(1, "please insert a quantity > 0 or remove the item"),
+    })),
+    cost: z.number(),
+    location_id: z.number().min(1, "Please select a location")
+}).superRefine((val, ctx) => {
+    if (val.return_items.length < 1) {
+        ctx.addIssue(
+            {
+                code: z.ZodIssueCode.custom,
+                message: `At least one product should be selected.`,
+                path: [`cost`]
+            }
+        )
+    }
+});
+
+export type CreateUnknownReturnSchema = z.infer<typeof createUnknownReturnSchema>;

--- a/src/services/return-service.ts
+++ b/src/services/return-service.ts
@@ -1,5 +1,7 @@
 import { baseUrl } from "@/app/constants";
-import { CreateSaleReturnSchema } from "@/schemas/return-schema";
+import { Return } from "@/models/data/return.model";
+import { APIResponse } from "@/models/responses/api-response.model";
+import { CreateSaleReturnSchema, CreateUnknownReturnSchema } from "@/schemas/return-schema";
 
 
 export const createReturnSale = async (data: CreateSaleReturnSchema) => {
@@ -19,4 +21,61 @@ export const createReturnSale = async (data: CreateSaleReturnSchema) => {
 
     const createdReturn = await response.json();
     return createdReturn;
+}
+
+
+export const createCompanyUnknownReturn = async (data: CreateUnknownReturnSchema): Promise<APIResponse<Return>> => {
+    const response = await fetch(`${baseUrl}/company-unknown-returns`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`
+        },
+        body: JSON.stringify(data)
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to create unknown return.");
+    }
+
+    const createdReturn = await response.json();
+    return createdReturn;
+
+}
+
+export const getCompanyUnknownReturns = async (comapnyID: number): Promise<APIResponse<Return[]>> => {
+    const response = await fetch(`${baseUrl}/company-unknown-returns/${comapnyID}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`
+        },
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to get unknown returns.");
+    }
+
+    const returns = await response.json();
+    return returns;
+}
+
+export const removeCompanyUnknownReturn = async (returnID: number): Promise<APIResponse<Return>> => {
+    const response = await fetch(`${baseUrl}/company-unknown-returns/${returnID}`, {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`
+        },
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to remove unknown return.");
+    }
+
+    const removedReturn = await response.json();
+    return removedReturn;
 }


### PR DESCRIPTION
- Introduced `CompanyUnknownReturnsPage` for displaying unknown returns in the dashboard.
- Updated return model and schema to include `company_id` and `franchise_id`.
- Implemented API services for creating, retrieving, and removing unknown returns.
- Enhanced the company control panel with a new menu item for unknown returns.

These changes improve the management of unknown returns, providing users with a dedicated interface and backend support.