### PR TITLE
feat(franchise-sales): Refactor franchise sales API integration

### DIFF
--- a/src/components/feature-specific/franchise-sales/franchise-sales-body.tsx
+++ b/src/components/feature-specific/franchise-sales/franchise-sales-body.tsx
@@ -2,7 +2,7 @@ import { RootState } from "@/app/store";
 import { companySalesColumns } from "@/components/feature-specific/company-sales/company-sales-columns";
 import { DataTable } from "@/components/ui/data-table";
 import { useToast } from "@/hooks/use-toast";
-import { getCompanyFranchiseSales } from "@/services/franchise-service";
+import { getFranchiseSales } from "@/services/franchise-service";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
@@ -14,7 +14,7 @@ export default function () {
 
   const { data } = useQuery({
     queryKey: ["sales"],
-    queryFn: () => getCompanyFranchiseSales(franchise.ID),
+    queryFn: () => getFranchiseSales(franchise.ID),
   });
   const { toast } = useToast();
 

--- a/src/services/franchise-service.ts
+++ b/src/services/franchise-service.ts
@@ -243,6 +243,24 @@ export const getCompanyFranchiseSales = async (franchiseID: number): Promise<API
     return apiResponse;
 
 }
+export const getFranchiseSales = async (franchiseID: number): Promise<APIResponse<Sale[]>> => {
+    const response = await fetch(`${baseUrl}/franchise/sales/${franchiseID}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${localStorage.getItem('my-franchise-user-token')}`
+        },
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to create entry bill.");
+    }
+
+    const apiResponse: APIResponse<Sale[]> = await response.json();
+    return apiResponse;
+
+}
 
 export const createFranchiseSale = async (data: CreateSaleSchema): Promise<APIResponse<Sale>> => {
     const response = await fetch(`${baseUrl}/franchise/sale`, {


### PR DESCRIPTION
- Renamed `getCompanyFranchiseSales` to `getFranchiseSales` for clarity and consistency.
- Updated the `franchise-sales-body` component to utilize the new `getFranchiseSales` function for fetching sales data.

These changes streamline the API service naming and improve the readability of the franchise sales component.