### PR TITLE
feat(sale-schema): Validate quantity in sale item schema

### DIFF
--- a/src/schemas/sale.ts
+++ b/src/schemas/sale.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 const saleItemSchema = z.object({
     product_variant_id: z.number(),
     discount: z.number(),
-    quantity: z.number()
+    quantity: z.number().min(1, {
+        message: "Quantity must be greater than 0"
+    })
 })
 
 export const createSaleSchema = z.object({


### PR DESCRIPTION
- Updated the `quantity` field in the `saleItemSchema` to enforce a minimum value of 1, ensuring that the quantity must be greater than 0. This change improves data integrity by preventing invalid sale entries.