### PR TITLE
fix(company-unknown-returns): Remove unused variable in barcode scann…

### DIFF
--- a/src/components/feature-specific/company-unknown-returns/add-company-unknown-return-dialog.tsx
+++ b/src/components/feature-specific/company-unknown-returns/add-company-unknown-return-dialog.tsx
@@ -83,7 +83,6 @@ export default function () {
   useEffect(() => {
     let timeout = setTimeout(() => {
       if (input.length != 0) {
-        let found = false;
         for (let item of inventory?.data?.items ?? []) {
           if (item.product_variant?.qr_code.includes(input)) {
             toast({
@@ -100,7 +99,7 @@ export default function () {
                 `return_items.${inputIndex}.quantity`,
                 form.watch(`return_items.${inputIndex}.quantity`) + 1
               );
-              found = true;
+          
               break;
             } else {
               form.setValue(


### PR DESCRIPTION
…ing logic

- Eliminated the `found` variable from the `useEffect` hook in the `AddCompanyUnknownReturnDialog` component, simplifying the barcode scanning logic.
- This change enhances code clarity and maintains the functionality of adding products to returns via barcode scanning.