### PR TITLE
feat(franchise-bills): Update exit bill status display with badges

### DIFF
--- a/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-exit-bills-columns.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-bills/franchise-bills-tabs/franchise-exit-bills-columns.tsx
@@ -1,12 +1,13 @@
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ExitBill } from "@/models/data/bill.model";
 import { ColumnDef } from "@tanstack/react-table";
@@ -82,7 +83,7 @@ export const franchiseExitBillsColumns: ColumnDef<ExitBill>[] = [
         </Button>
       );
     },
-    cell: ({ row }) => `EXB-${row.original.ID}`,
+    cell: ({ row }) => row.original.entry_bill == null ? <Badge variant={'destructive'}>Pending</Badge> : <Badge variant={'secondary'}>Acquired</Badge>,
   },
   {
     accessorKey: "franchise_total_amount",


### PR DESCRIPTION
- Modified the `franchise-exit-bills-columns` to replace the cell rendering logic for the entry bill ID with a badge indicating the status of the exit bill.
- Introduced a conditional rendering of badges to show "Pending" or "Acquired" based on the entry bill's presence, enhancing the clarity of exit bill statuses.

These changes improve the user experience by providing immediate visual feedback on the status of exit bills.