### PR TITLE
feat(sales): Add PDF download and print functionality for sales receipts

### DIFF
--- a/src/components/feature-specific/company-sales/add-company-sale-dialog.tsx
+++ b/src/components/feature-specific/company-sales/add-company-sale-dialog.tsx
@@ -29,7 +29,7 @@ import { useToast } from "@/hooks/use-toast";
 import { SaleItemEntity } from "@/models/data/sale.model";
 import { CreateSaleSchema, createSaleSchema } from "@/schemas/sale";
 import { getCompanyInventory } from "@/services/inventory-service";
-import { createCompanySale } from "@/services/sale-service";
+import { createCompanySale, downloadAndPrintPDF } from "@/services/sale-service";
 import { processSaleBarcode } from "@/utils/process-sale-barcodes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -53,6 +53,7 @@ export default function () {
       discount: 0,
     },
   });
+
   const { data: inventory } = useQuery({
     queryKey: ["inventory"],
     queryFn: () => getCompanyInventory(company.ID),
@@ -139,14 +140,19 @@ export default function () {
     );
   }
   const queryClient = useQueryClient();
+  const {mutate: downloadAndPrintPDFMutation} = useMutation({
+    mutationFn: downloadAndPrintPDF,
+   
+  })
   const { mutate: createCompanySaleMutation, isPending } = useMutation({
     mutationFn: createCompanySale,
-    onSuccess: () => {
+    onSuccess: (data) => {
       setOpen(false);
       toast({
         title: "Sale Created",
         description: "Sale was created successfully",
       });
+      downloadAndPrintPDFMutation(data.data?.ID ?? 0)
       form.reset();
       setSaleItems([]);
       queryClient.invalidateQueries({

--- a/src/components/feature-specific/company-sales/company-sales-actions-dropdown.tsx
+++ b/src/components/feature-specific/company-sales/company-sales-actions-dropdown.tsx
@@ -1,13 +1,15 @@
 import { Button } from "@/components/ui/button";
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Sale } from "@/models/data/sale.model";
-import { MoreHorizontal } from "lucide-react";
+import { downloadAndPrintPDF } from "@/services/sale-service";
+import { useMutation } from "@tanstack/react-query";
+import { MoreHorizontal, Printer } from "lucide-react";
 import CompanyRemoveSaleDialog from "./company-remove-sale-dialog";
 import CompanySaleDetailsDialog from "./company-sale-details-dialog";
 import CreateSaleReturnDialog from "./create-sale-return-dialog";
@@ -17,6 +19,9 @@ interface Props {
 }
 
 export default function ({ sale }: Props) {
+  const { mutate: downloadAndPrintMutation } = useMutation({
+    mutationFn: downloadAndPrintPDF,
+  });
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -34,9 +39,12 @@ export default function ({ sale }: Props) {
         </DropdownMenuItem>
         <CompanySaleDetailsDialog sale={sale} />
         <CreateSaleReturnDialog sale={sale} />
+        <DropdownMenuItem onClick={() => downloadAndPrintMutation(sale.ID)}>
+          <Printer />
+          Print Receipt
+        </DropdownMenuItem>
         <CompanyRemoveSaleDialog sale={sale} />
       </DropdownMenuContent>
-
     </DropdownMenu>
   );
 }

--- a/src/components/feature-specific/company-sales/print-receipt-dialog.tsx
+++ b/src/components/feature-specific/company-sales/print-receipt-dialog.tsx
@@ -1,0 +1,24 @@
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "@/components/ui/dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { Sale } from "@/models/data/sale.model";
+import { Printer } from "lucide-react";
+
+
+interface Props {
+    sale: Sale;
+}
+
+export default function({}: Props) {
+    return <Dialog>
+        <DialogTrigger asChild>
+            <DropdownMenuItem onSelect={e => e.preventDefault()}>
+                <Printer /> 
+                Print Receipt
+            </DropdownMenuItem>
+        </DialogTrigger>
+        <DialogContent>
+            <DialogHeader>
+            </DialogHeader>
+        </DialogContent>
+    </Dialog>
+}

--- a/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
+++ b/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
@@ -1,34 +1,34 @@
 import { RootState } from "@/app/store";
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormMessage,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { SaleItemEntity } from "@/models/data/sale.model";
 import { CreateSaleSchema, createSaleSchema } from "@/schemas/sale";
-import { createFranchiseSale, getFranchiseInventory } from "@/services/franchise-service";
+import { createFranchiseSale, downloadAndPrintFranchisePDF, getFranchiseInventory } from "@/services/franchise-service";
 import { processSaleBarcode } from "@/utils/process-sale-barcodes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -138,14 +138,19 @@ export default function () {
     );
   }
   const queryClient = useQueryClient();
+  const {mutate: downloadAndPrintFranchisePDFMutation }= useMutation({
+    mutationFn: downloadAndPrintFranchisePDF
+    
+  });
   const { mutate: createFranchiseSaleMutation, isPending } = useMutation({
     mutationFn: createFranchiseSale,
-    onSuccess: () => {
+    onSuccess: (data) => {
       setOpen(false);
       toast({
         title: "Sale Created",
         description: "Sale was created successfully",
       });
+      downloadAndPrintFranchisePDFMutation(data?.data?.ID ?? 0)
       form.reset();
       setSaleItems([]);
       queryClient.invalidateQueries({

--- a/src/components/feature-specific/franchise-sales/franchise-sales-actions-dropdown.tsx
+++ b/src/components/feature-specific/franchise-sales/franchise-sales-actions-dropdown.tsx
@@ -1,21 +1,25 @@
 import CompanySaleDetailsDialog from "@/components/feature-specific/company-sales/company-sale-details-dialog";
 import { Button } from "@/components/ui/button";
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Sale } from "@/models/data/sale.model";
-import { MoreHorizontal } from "lucide-react";
-
+import { downloadAndPrintFranchisePDF } from "@/services/franchise-service";
+import { useMutation } from "@tanstack/react-query";
+import { MoreHorizontal, Printer } from "lucide-react";
 
 interface Props {
   sale: Sale;
 }
 
 export default function ({ sale }: Props) {
+  useMutation({
+    mutationFn: downloadAndPrintFranchisePDF,
+  });
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -32,10 +36,13 @@ export default function ({ sale }: Props) {
           Copy sale ID
         </DropdownMenuItem>
         <CompanySaleDetailsDialog sale={sale} />
+        <DropdownMenuItem onClick={() => downloadAndPrintFranchisePDF(sale.ID)}>
+          <Printer />
+          Print Receipt
+        </DropdownMenuItem>
         {/* <CreateSaleReturnDialog sale={sale} /> */}
         {/* <FranchiseRemoveSaleDialog sale={sale} /> */}
       </DropdownMenuContent>
-
     </DropdownMenu>
   );
 }

--- a/src/services/franchise-service.ts
+++ b/src/services/franchise-service.ts
@@ -357,3 +357,32 @@ export const getCompanyFranchiseSalesTotal = async (franchiseID: number, from: D
     const apiResponse: APIResponse<{ total_amount: number, total_franchise_price:number }> = await response.json();
     return apiResponse;
 }
+
+export const downloadAndPrintFranchisePDF = async (saleID: number): Promise<void> => {
+    const response = await fetch(`${baseUrl}/franchise/sales/receipt/${saleID}`, {
+        method: 'GET',
+        headers: {
+            'Authorization': `Bearer ${localStorage.getItem('my-franchise-user-token')}`
+        }
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to download PDF.");
+    }
+
+    const blob = await response.blob();
+    const url = window.URL.createObjectURL(blob);
+    
+    const printWindow = window.open(url);
+    if (printWindow) {
+        printWindow.onload = () => {
+            printWindow.print();
+            printWindow.onafterprint = () => {
+                printWindow.close();
+            };
+        };
+    } else {
+        throw new Error("Failed to open print window.");
+    }
+}

--- a/src/services/sale-service.ts
+++ b/src/services/sale-service.ts
@@ -111,3 +111,32 @@ export const removeCompanyFranchiseSale = async (saleID: number): Promise<APIRes
     const apiResponse: APIResponse<void> = await response.json();
     return apiResponse;
 }
+
+export const downloadAndPrintPDF = async (saleID: number): Promise<void> => {
+    const response = await fetch(`${baseUrl}/sales/receipt/${saleID}`, {
+        method: 'GET',
+        headers: {
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`
+        }
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to download PDF.");
+    }
+
+    const blob = await response.blob();
+    const url = window.URL.createObjectURL(blob);
+    
+    const printWindow = window.open(url);
+    if (printWindow) {
+        printWindow.onload = () => {
+            printWindow.print();
+            printWindow.onafterprint = () => {
+                printWindow.close();
+            };
+        };
+    } else {
+        throw new Error("Failed to open print window.");
+    }
+}


### PR DESCRIPTION
- Integrated `downloadAndPrintPDF` and `downloadAndPrintFranchisePDF` functions into the company and franchise sales components, allowing users to print receipts directly from the sales actions dropdown.
- Updated the `onSuccess` callback of the sale creation mutation to trigger the PDF download after a successful sale creation, enhancing user experience by providing immediate access to the receipt.
- Improved the overall functionality of the sales components by adding print options, streamlining the sales process for users.

These changes enhance the usability of the sales components by providing convenient receipt printing options.