### PR TITLE
refactor(company-sales): Remove PDF download functionality from sale creation process

### DIFF
--- a/src/components/feature-specific/company-sales/add-company-sale-dialog.tsx
+++ b/src/components/feature-specific/company-sales/add-company-sale-dialog.tsx
@@ -29,7 +29,7 @@ import { useToast } from "@/hooks/use-toast";
 import { SaleItemEntity } from "@/models/data/sale.model";
 import { CreateSaleSchema, createSaleSchema } from "@/schemas/sale";
 import { getCompanyInventory } from "@/services/inventory-service";
-import { createCompanySale, downloadAndPrintPDF } from "@/services/sale-service";
+import { createCompanySale } from "@/services/sale-service";
 import { processSaleBarcode } from "@/utils/process-sale-barcodes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -140,19 +140,16 @@ export default function () {
     );
   }
   const queryClient = useQueryClient();
-  const {mutate: downloadAndPrintPDFMutation} = useMutation({
-    mutationFn: downloadAndPrintPDF,
-   
-  })
+
   const { mutate: createCompanySaleMutation, isPending } = useMutation({
     mutationFn: createCompanySale,
-    onSuccess: (data) => {
+    onSuccess: () => {
       setOpen(false);
       toast({
         title: "Sale Created",
         description: "Sale was created successfully",
       });
-      downloadAndPrintPDFMutation(data.data?.ID ?? 0)
+      // downloadAndPrintPDFMutation(data.data?.ID ?? 0)
       form.reset();
       setSaleItems([]);
       queryClient.invalidateQueries({


### PR DESCRIPTION
- Eliminated the `downloadAndPrintPDF` mutation from the `add-company-sale-dialog` component, streamlining the sale creation process.
- Updated the `onSuccess` callback to remove the PDF download trigger, simplifying the user experience after a sale is created.
- Adjusted related logic to ensure clarity and maintainability of the component.

These changes enhance the focus on sale creation without the immediate PDF download, improving the overall workflow for users.