### PR TITLE
feat(franchise-sales): Add default sale type for franchise sales

### DIFF
--- a/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
+++ b/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
@@ -50,6 +50,7 @@ export default function () {
       location_id: franchise.ID,
       sale_items: [],
       discount: 0,
+      sale_type: "franchise",
     },
   });
   const { data: inventory } = useQuery({


### PR DESCRIPTION
- Updated the `add-franchise-sale-dialog` component to include a default `sale_type` of "franchise" for new sales, ensuring consistency in sale categorization.

This change improves the clarity and organization of franchise sales data by standardizing the sale type upon creation.