### PR TITLE
feat(company-stats): add company stats page with product sales data

### DIFF
--- a/src/components/feature-specific/company/company-stats/company-stats-body.tsx
+++ b/src/components/feature-specific/company/company-stats/company-stats-body.tsx
@@ -1,0 +1,99 @@
+import { RootState } from "@/app/store";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DataTable } from "@/components/ui/data-table";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { getProductSales } from "@/services/product-service";
+import { useQuery } from "@tanstack/react-query";
+import { format, subMonths } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { useState } from "react";
+import { DateRange } from "react-day-picker";
+import { useSelector } from "react-redux";
+import { companyStatsColumns } from "./company-stats-columns";
+
+export default function CompanyStatsBody() {
+  const company = useSelector((state: RootState) => state.company.company);
+  if (!company) {
+    return <div>No company selected</div>;
+  }
+  const [date, setDate] = useState<DateRange | undefined>({
+    from: subMonths(new Date(), 1),
+    to: new Date(),
+  });
+  const { data } = useQuery({
+    queryKey: [
+      "product-sales",
+      company?.ID || 0,
+      date?.from || new Date(),
+      date?.to || new Date(),
+    ],
+    queryFn: () =>
+      getProductSales({
+        company_id: company?.ID || 0,
+        start_date: date?.from || new Date(),
+        end_date: date?.to || new Date(),
+      }),
+    // enabled: !!company?.ID && !!date?.from && !!date?.to,
+  });
+
+
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>Company Stats</span>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={cn(
+                  "justify-start text-left font-normal",
+                  !date && "text-muted-foreground"
+                )}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {date?.from ? (
+                  date.to ? (
+                    <>
+                      {format(date.from, "LLL dd, y")} -{" "}
+                      {format(date.to, "LLL dd, y")}
+                    </>
+                  ) : (
+                    format(date.from, "LLL dd, y")
+                  )
+                ) : (
+                  <span>Pick a date range</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="end">
+              <Calendar
+                initialFocus
+                mode="range"
+                defaultMonth={date?.from}
+                selected={date}
+                onSelect={setDate}
+                numberOfMonths={2}
+              />
+            </PopoverContent>
+          </Popover>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <DataTable
+          columns={companyStatsColumns}
+          data={data?.data || []}
+          searchColumn="name"
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/feature-specific/company/company-stats/company-stats-columns.tsx
+++ b/src/components/feature-specific/company/company-stats/company-stats-columns.tsx
@@ -1,0 +1,60 @@
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from "@/components/ui/accordion";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { ProductSalesResponse } from "@/models/responses/company-stats.model";
+import { ColumnDef } from "@tanstack/react-table";
+
+export const companyStatsColumns: ColumnDef<ProductSalesResponse>[] = [
+  {
+    header: "Product",
+    accessorKey: "name",
+    id: "name"
+  },
+
+  {
+    header: "Variants",
+    accessorKey: "variants",
+    cell: ({ row }) => {
+      return (
+        <Accordion type="single" collapsible>
+          <AccordionItem value={row.original.product_id.toString()}>
+            <AccordionTrigger>{row.original.name}</AccordionTrigger>
+            <AccordionContent>
+              <Table>
+                <TableHeader>
+                  <TableHead>Color</TableHead>
+                  <TableHead>Size</TableHead>
+                  <TableHead>Sold Quantity</TableHead>
+                </TableHeader>
+                <TableBody>
+                  {row.original.variants.map((variant) => (
+                    <TableRow key={variant.product_variant_id}>
+                      <TableCell>{variant.color}</TableCell>
+                      <TableCell>{variant.size}</TableCell>
+                      <TableCell>{variant.sold_quantity}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      );
+    },
+  },
+  {
+    header: "Total Sold Quantity",
+    accessorKey: "total_sold_quantity",
+  },
+];

--- a/src/models/responses/company-stats.model.ts
+++ b/src/models/responses/company-stats.model.ts
@@ -1,0 +1,18 @@
+
+export interface ProductSalesResponse {
+  product_id: number;
+  name: string;
+  variants: VariantSalesResponse[];
+  total_sold_quantity: number;
+}
+
+export interface VariantSalesResponse {
+  product_variant_id: number;
+  color: string;
+  size: number;
+  sold_quantity: number;
+}
+
+export interface CompanyStats {
+  productSales: ProductSalesResponse[];
+}

--- a/src/pages/dashboard/company/company-stats-page.tsx
+++ b/src/pages/dashboard/company/company-stats-page.tsx
@@ -1,9 +1,11 @@
 import CompanyStatsAppBar from "@/components/feature-specific/company/company-stats/company-stats-app-bar";
+import CompanyStatsBody from "@/components/feature-specific/company/company-stats/company-stats-body";
 
 export default function () {
   return (
     <div className="p-4">
       <CompanyStatsAppBar />
+      <CompanyStatsBody />
     </div>
   );
 }

--- a/src/schemas/product.ts
+++ b/src/schemas/product.ts
@@ -73,3 +73,12 @@ export const createProductVariantSchema = z.object({
 });
 
 export type CreateProductVariantSchema = z.infer<typeof createProductVariantSchema>
+
+
+export const salesQuantityRequestSchema = z.object({
+    company_id: z.number(),
+    start_date: z.date(),
+    end_date: z.date(),
+});
+
+export type SalesQuantityRequestSchema = z.infer<typeof salesQuantityRequestSchema>

--- a/src/services/product-service.ts
+++ b/src/services/product-service.ts
@@ -1,7 +1,8 @@
 import { baseUrl } from "@/app/constants";
 import { Product, ProductVariant } from "@/models/data/product.model";
 import { APIResponse } from "@/models/responses/api-response.model";
-import { CreateProductSchema, CreateProductVariantSchema, GenerateBarcodePDFSchema, UpdateProductSchema } from "@/schemas/product";
+import { ProductSalesResponse } from "@/models/responses/company-stats.model";
+import { CreateProductSchema, CreateProductVariantSchema, GenerateBarcodePDFSchema, SalesQuantityRequestSchema, UpdateProductSchema } from "@/schemas/product";
 
 export const createProduct = async (productData: CreateProductSchema): Promise<APIResponse<Product>> => {
     const response = await fetch(`${baseUrl}/products`, {
@@ -216,5 +217,24 @@ export const createProductVariant = async (productVariantData: CreateProductVari
 
     const createdProductVariant: APIResponse<ProductVariant> = await response.json();
     return createdProductVariant;
+}
+
+
+export const getProductSales = async (data: SalesQuantityRequestSchema): Promise<APIResponse<ProductSalesResponse[]>> => {
+    const response = await fetch(`${baseUrl}/products/sales-quantities/${data.company_id}?startDate=${data.start_date.toISOString().split('T')[0]}&endDate=${data.end_date.toISOString().split('T')[0]}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`
+        },
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to get product sales.");
+    }
+
+    const apiResponse: APIResponse<ProductSalesResponse[]> = await response.json();
+    return apiResponse;
 }
 


### PR DESCRIPTION
Introduce a new company stats page that displays product sales data within a specified date range. The page includes a data table with product and variant details, a date range picker, and integration with the product service to fetch sales data. This feature enhances the dashboard by providing insights into company performance.