### PR TITLE
fix(company-stats): enable query when company ID and dates are present

### DIFF
--- a/src/components/feature-specific/company/company-stats/company-stats-body.tsx
+++ b/src/components/feature-specific/company/company-stats/company-stats-body.tsx
@@ -40,7 +40,7 @@ export default function CompanyStatsBody() {
         start_date: date?.from || new Date(),
         end_date: date?.to || new Date(),
       }),
-    // enabled: !!company?.ID && !!date?.from && !!date?.to,
+    enabled: !!company?.ID && !!date?.from && !!date?.to,
   });
 
 


### PR DESCRIPTION
The query was previously commented out, preventing the component from fetching data even when the necessary conditions were met. This change ensures the query is enabled when a company ID and valid date range are provided, allowing the component to function as intended.