### PR TITLE
feat(company-stats): add pagination support for product sales data

### DIFF
--- a/src/components/feature-specific/company/company-stats/company-stats-body.tsx
+++ b/src/components/feature-specific/company/company-stats/company-stats-body.tsx
@@ -27,18 +27,21 @@ export default function CompanyStatsBody() {
     from: subMonths(new Date(), 1),
     to: new Date(),
   });
+  const [currentPage, setCurrentPage] = useState(0);
   const { data } = useQuery({
     queryKey: [
       "product-sales",
       company?.ID || 0,
       date?.from || new Date(),
       date?.to || new Date(),
+      currentPage,
     ],
     queryFn: () =>
       getProductSales({
         company_id: company?.ID || 0,
         start_date: date?.from || new Date(),
         end_date: date?.to || new Date(),
+        page: currentPage + 1,
       }),
     enabled: !!company?.ID && !!date?.from && !!date?.to,
   });
@@ -90,8 +93,12 @@ export default function CompanyStatsBody() {
       <CardContent>
         <DataTable
           columns={companyStatsColumns}
-          data={data?.data || []}
+          data={data?.data?.products || []}
           searchColumn="name"
+          paginationMeta={data?.data?.pagination}
+          onPageChange={(page) => setCurrentPage(page)}
+          currentPage={currentPage}
+          
         />
       </CardContent>
     </Card>

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -19,6 +19,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { PaginationMeta } from "@/models/responses/company-stats.model";
 import React from "react";
 import { Button } from "./button";
 import {
@@ -32,13 +33,19 @@ import { Input } from "./input";
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
-  searchColumn:string;
+  searchColumn: string;
+  paginationMeta?: PaginationMeta;
+  onPageChange?: (page: number) => void;
+  currentPage?: number;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
-  searchColumn
+  searchColumn,
+  paginationMeta,
+  onPageChange,
+  currentPage = 0
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -59,11 +66,17 @@ export function DataTable<TData, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    manualPagination: !!onPageChange,
+    pageCount: paginationMeta?.total_pages ?? -1,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
       rowSelection,
+      pagination: {
+        pageIndex: currentPage,
+        pageSize: paginationMeta?.per_page ?? 10
+      }
     },
   });
 
@@ -164,16 +177,27 @@ export function DataTable<TData, TValue>({
         <Button
           variant="outline"
           size="sm"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
+          onClick={() => {
+            const newPage = currentPage - 1;
+            onPageChange?.(newPage);
+          }}
+          disabled={currentPage <= 0}
         >
           Previous
         </Button>
+        <div className="flex items-center gap-2 mx-2">
+          <span className="text-sm">
+            Page {currentPage + 1} of {paginationMeta?.total_pages ?? 1}
+          </span>
+        </div>
         <Button
           variant="outline"
           size="sm"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
+          onClick={() => {
+            const newPage = currentPage + 1;
+            onPageChange?.(newPage);
+          }}
+          disabled={currentPage >= (paginationMeta?.total_pages ?? 1) - 1}
         >
           Next
         </Button>

--- a/src/models/responses/company-stats.model.ts
+++ b/src/models/responses/company-stats.model.ts
@@ -12,7 +12,14 @@ export interface VariantSalesResponse {
   size: number;
   sold_quantity: number;
 }
+export interface PaginationMeta {
+  total_items: number;
+  total_pages: number;
+  current_page: number;
+  per_page: number;
+}
 
-export interface CompanyStats {
-  productSales: ProductSalesResponse[];
+export interface CompanyStatsResponse {
+  products: ProductSalesResponse[];
+  pagination: PaginationMeta;
 }

--- a/src/schemas/product.ts
+++ b/src/schemas/product.ts
@@ -79,6 +79,8 @@ export const salesQuantityRequestSchema = z.object({
     company_id: z.number(),
     start_date: z.date(),
     end_date: z.date(),
+    page: z.number().optional(),
+    limit: z.number().optional(),
 });
 
 export type SalesQuantityRequestSchema = z.infer<typeof salesQuantityRequestSchema>

--- a/src/services/product-service.ts
+++ b/src/services/product-service.ts
@@ -1,7 +1,7 @@
 import { baseUrl } from "@/app/constants";
 import { Product, ProductVariant } from "@/models/data/product.model";
 import { APIResponse } from "@/models/responses/api-response.model";
-import { ProductSalesResponse } from "@/models/responses/company-stats.model";
+import { CompanyStatsResponse } from "@/models/responses/company-stats.model";
 import { CreateProductSchema, CreateProductVariantSchema, GenerateBarcodePDFSchema, SalesQuantityRequestSchema, UpdateProductSchema } from "@/schemas/product";
 
 export const createProduct = async (productData: CreateProductSchema): Promise<APIResponse<Product>> => {
@@ -220,8 +220,8 @@ export const createProductVariant = async (productVariantData: CreateProductVari
 }
 
 
-export const getProductSales = async (data: SalesQuantityRequestSchema): Promise<APIResponse<ProductSalesResponse[]>> => {
-    const response = await fetch(`${baseUrl}/products/sales-quantities/${data.company_id}?startDate=${data.start_date.toISOString().split('T')[0]}&endDate=${data.end_date.toISOString().split('T')[0]}`, {
+export const getProductSales = async (data: SalesQuantityRequestSchema): Promise<APIResponse<CompanyStatsResponse>> => {
+    const response = await fetch(`${baseUrl}/products/sales-quantities/${data.company_id}?startDate=${data.start_date.toISOString().split('T')[0]}&endDate=${data.end_date.toISOString().split('T')[0]}&page=${data.page}&limit=${data.limit}`, {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',
@@ -234,7 +234,7 @@ export const getProductSales = async (data: SalesQuantityRequestSchema): Promise
         throw new Error(errorData.message || "Failed to get product sales.");
     }
 
-    const apiResponse: APIResponse<ProductSalesResponse[]> = await response.json();
+    const apiResponse: APIResponse<CompanyStatsResponse> = await response.json();
     return apiResponse;
 }
 


### PR DESCRIPTION
Implement pagination for the product sales data in the company stats feature. This includes adding pagination parameters to the API request, updating the response schema to include pagination metadata, and modifying the data table component to handle pagination controls. This change improves performance and usability when dealing with large datasets.