### PR TITLE
feat(company-bills): add PDF download functionality for exit bills

### DIFF
--- a/src/components/feature-specific/company-bills/company-bill-dialog.tsx
+++ b/src/components/feature-specific/company-bills/company-bill-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ExitBill } from "@/models/data/bill.model";
+import { downloadExitBillPDF } from "@/services/bill-service";
 import { CircleX, LucideTicket, Printer } from "lucide-react";
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
@@ -19,7 +20,7 @@ interface Props {
 
 export default function ({ bill }: Props) {
   const [open, setOpen] = useState(false);
-  const {pathname} = useLocation();
+  const { pathname } = useLocation();
   const isModerator = pathname.includes("moderator");
 
   return (
@@ -43,11 +44,16 @@ export default function ({ bill }: Props) {
           </div>
           <div className="flex gap-2">
             <span className="font-bold">Date:</span>
-            <p className="text-white font-bold">{new Date(bill.franchise?.CreatedAt ?? "").toDateString()}</p>
+            <p className="text-white font-bold">
+              {new Date(bill.franchise?.CreatedAt ?? "").toDateString()}
+            </p>
           </div>
           <ScrollArea className="max-h-[400px]">
             {bill.bill_items.map((billItem) => (
-              <div key={`bill-item-${billItem.id}`} className="flex justify-between">
+              <div
+                key={`bill-item-${billItem.id}`}
+                className="flex justify-between"
+              >
                 <span className="text-white">
                   {billItem.product_variant.product?.name}{" "}
                   {billItem.product_variant.color}{" "}
@@ -68,7 +74,9 @@ export default function ({ bill }: Props) {
                 }).format(bill.franchise_total_amount)}
               </span>
             </div>
-            <div className={`flex justify-between ${isModerator ? "hidden": ""}`}>
+            <div
+              className={`flex justify-between ${isModerator ? "hidden" : ""}`}
+            >
               <span>Company Spent:</span>
               <span className="text-white font-bold">
                 {new Intl.NumberFormat("en-DZ", {
@@ -77,7 +85,9 @@ export default function ({ bill }: Props) {
                 }).format(bill.company_total_amount)}
               </span>
             </div>
-            <div className={`flex justify-between ${isModerator ? "hidden": ""}`}>
+            <div
+              className={`flex justify-between ${isModerator ? "hidden" : ""}`}
+            >
               <span>Benefits:</span>
               <span className="text-white font-bold">
                 {new Intl.NumberFormat("en-DZ", {
@@ -94,7 +104,7 @@ export default function ({ bill }: Props) {
                 Close
               </Button>
             </DialogTrigger>
-            <Button>
+            <Button onClick={() => downloadExitBillPDF(bill.ID)}>
               <Printer />
               Print
             </Button>

--- a/src/services/bill-service.ts
+++ b/src/services/bill-service.ts
@@ -99,3 +99,46 @@ export const recordFranchisePayment = async (data: CreateFranchisePayment): Prom
     const apiResponse: APIResponse<any> = await response.json();
     return apiResponse;
 }
+
+export const downloadExitBillPDF = async (exitBillID: number): Promise<void> => {
+    try {
+        const response = await fetch(`${baseUrl}/bills/exit/${exitBillID}/print`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${localStorage.getItem('token')}`
+            }
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(errorData.message || "Failed to download exit bill PDF.");
+        }
+
+        // Convert the response to a blob
+        const blob = await response.blob();
+        
+        // Create a URL for the blob
+        const url = window.URL.createObjectURL(blob);
+        
+        // Open the PDF in a new tab
+        const newWindow = window.open(url, '_blank');
+        
+        if (!newWindow) {
+            throw new Error("Popup blocked. Please allow popups for this site.");
+        }
+        
+        // Trigger the print dialog once the PDF is loaded
+        newWindow.addEventListener('load', () => {
+            newWindow.print();
+        });
+        
+        // Clean up the URL object after a delay to ensure the PDF has loaded
+        setTimeout(() => {
+            window.URL.revokeObjectURL(url);
+        }, 1000);
+    } catch (error) {
+        console.error("Error printing exit bill PDF:", error);
+        throw error;
+    }
+};
+


### PR DESCRIPTION
- Implemented a new service to download exit bill PDFs, enhancing the ability to print bills directly from the application.
- Updated the company bill dialog component to include a print button that triggers the PDF download, improving user experience and accessibility of bill information.

These changes streamline the process of accessing and printing exit bills, providing users with a more efficient way to manage their billing documents.