### PR TITLE
feat(date-range-picker): enhance date selection with single date toggle and reset functionality

### DIFF
--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -1,15 +1,17 @@
 "use client";
 
+import { Checkbox } from "@/components/ui/checkbox";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
+import * as React from "react";
 import { DateRange } from "react-day-picker";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
@@ -21,11 +23,69 @@ interface DatePickerWithRangeProps {
 
 export function DatePickerWithRange({
   className,
-  date,
+  date: externalDate,
   onSelect,
 }: DatePickerWithRangeProps) {
+  const [singleDateOnly, setSingleDateOnly] = React.useState(false);
+  const [selectedRange, setSelectedRange] = React.useState<DateRange | undefined>(externalDate);
+  const [selectedSingle, setSelectedSingle] = React.useState<Date | undefined>(undefined);
+
+  // Sync with external date prop
+  React.useEffect(() => {
+    setSelectedRange(externalDate);
+  }, [externalDate]);
+
+  // Handle selection change
+  const handleSelect = (value: DateRange | Date | undefined) => {
+    if (singleDateOnly) {
+      setSelectedSingle(value as Date | undefined);
+      onSelect(
+        value
+          ? { from: value as Date, to: value as Date }
+          : undefined
+      );
+    } else {
+      setSelectedRange(value as DateRange | undefined);
+      onSelect(value as DateRange | undefined);
+    }
+  };
+
+  // Reset logic
+  const handleReset = () => {
+    setSelectedRange(undefined);
+    setSelectedSingle(undefined);
+    onSelect(undefined);
+  };
+
+  // Display logic
+  const displayValue = () => {
+    if (singleDateOnly) {
+      return selectedSingle
+        ? format(selectedSingle, "LLL dd, y")
+        : <span>Pick a date</span>;
+    } else {
+      if (selectedRange?.from) {
+        if (selectedRange.to) {
+          return <>{format(selectedRange.from, "LLL dd, y")} - {format(selectedRange.to, "LLL dd, y")}</>;
+        }
+        return format(selectedRange.from, "LLL dd, y");
+      }
+      return <span>Pick a date range</span>;
+    }
+  };
+
   return (
     <div className={cn("grid gap-2", className)}>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="single-date-toggle"
+          checked={singleDateOnly}
+          onCheckedChange={checked => setSingleDateOnly(!!checked)}
+        />
+        <label htmlFor="single-date-toggle" className="text-sm select-none cursor-pointer">
+          Single date only
+        </label>
+      </div>
       <Popover>
         <PopoverTrigger asChild>
           <Button
@@ -33,33 +93,38 @@ export function DatePickerWithRange({
             variant={"outline"}
             className={cn(
               "w-full justify-start text-left font-normal",
-              !date && "text-muted-foreground"
+              (!selectedRange && !selectedSingle) && "text-muted-foreground"
             )}
           >
             <CalendarIcon className="mr-2 h-4 w-4" />
-            {date?.from ? (
-              date.to ? (
-                <>
-                  {format(date.from, "LLL dd, y")} -{" "}
-                  {format(date.to, "LLL dd, y")}
-                </>
-              ) : (
-                format(date.from, "LLL dd, y")
-              )
-            ) : (
-              <span>Pick a date range</span>
-            )}
+            {displayValue()}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            initialFocus
-            mode="range"
-            defaultMonth={date?.from}
-            selected={date}
-            onSelect={onSelect}
-            numberOfMonths={2}
-          />
+          {singleDateOnly ? (
+            <Calendar
+              initialFocus
+              mode="single"
+              defaultMonth={selectedSingle ?? undefined}
+              selected={selectedSingle}
+              onSelect={(date) => handleSelect(date)}
+              numberOfMonths={2}
+            />
+          ) : (
+            <Calendar
+              initialFocus
+              mode="range"
+              defaultMonth={selectedRange?.from}
+              selected={selectedRange}
+              onSelect={(range) => handleSelect(range)}
+              numberOfMonths={2}
+            />
+          )}
+          <div className="flex justify-end p-2 border-t">
+            <Button size="sm" variant="ghost" onClick={handleReset}>
+              Reset
+            </Button>
+          </div>
         </PopoverContent>
       </Popover>
     </div>


### PR DESCRIPTION
- Added a checkbox to toggle between single date and date range selection, improving user flexibility in date picking.
- Implemented state management for selected dates and ranges, allowing for better synchronization with external date props.
- Introduced a reset button to clear selected dates, enhancing user experience by providing a straightforward way to start over.

These updates streamline the date selection process, making it more intuitive and user-friendly.