### PR TITLE
feat(company-franchises): update company selection logic for moderator role

### DIFF
--- a/src/components/feature-specific/company-franchises/make-bill-dialog.tsx
+++ b/src/components/feature-specific/company-franchises/make-bill-dialog.tsx
@@ -30,6 +30,7 @@ import { AppleIcon, Barcode, ReceiptText, Scan } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import MakeBillTile from "./make-bill-tile";
 
 interface Props {
@@ -39,7 +40,12 @@ interface Props {
 export default function ({ franchise }: Props) {
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
-  const company = useSelector((state: RootState) => state.company.company);
+  let company = useSelector((state: RootState) => state.company.company);
+  const { pathname } = useLocation();
+  const isModerator = pathname.includes("moderator");
+  if (isModerator) {
+    company = useSelector((state: RootState) => state.user.company);
+  }
   const [billItems, setBillItems] = useState<Array<BillItem>>([]);
   const { toast } = useToast();
   const form = useForm<CreateExitBillSchema>({


### PR DESCRIPTION


- Enhanced the make-bill-dialog component to conditionally select the company based on the user's role. If the user is a moderator, the company is now fetched from the user state instead of the default company state. This change improves data accuracy and ensures that moderators have access to the correct company information when creating bills.