### PR TITLE
fix(supplier-entry-bill-dialog, supplier-schema): allow nullable user…

### DIFF
--- a/src/components/feature-specific/company-suppliers/supplier-entry-bill-dialog.tsx
+++ b/src/components/feature-specific/company-suppliers/supplier-entry-bill-dialog.tsx
@@ -58,8 +58,8 @@ export default function ({ supplierID }: Props) {
     defaultValues: {
       company_id: company?.ID ?? 0,
       supplier_id: supplierID,
-      administrator_id: admin?.ID,
-      user_id: user?.ID,
+      administrator_id: admin?.ID ?? null,
+      user_id: user?.ID ?? null,
       items: [],
       total: 0,
     },

--- a/src/schemas/supplier.ts
+++ b/src/schemas/supplier.ts
@@ -12,8 +12,8 @@ export const createSupplierSchema = z.object({
 export const createSupplierBillSchema = z.object({
     supplier_id: z.number(),
     company_id: z.number(),
-    user_id: z.number(),
-    administrator_id: z.number(),
+    user_id: z.number().nullable(),
+    administrator_id: z.number().nullable(),
     items: z.array(z.object({
         product_variant_id: z.number(),
         quantity: z.number(),


### PR DESCRIPTION
… and administrator IDs

- Updated the supplier-entry-bill-dialog component to set user_id and administrator_id to null by default if not provided, enhancing flexibility in bill creation.
- Modified the supplier schema to accept nullable values for user_id and administrator_id, improving data validation and handling.

These changes ensure that the application can handle cases where user and administrator IDs are not available, enhancing overall robustness.