### PR TITLE
feat(company-stats): add sold warehouse and sold Algiers columns to company stats

### DIFF
--- a/src/components/feature-specific/company/company-stats/company-stats-columns.tsx
+++ b/src/components/feature-specific/company/company-stats/company-stats-columns.tsx
@@ -1,16 +1,16 @@
 import {
-    Accordion,
-    AccordionContent,
-    AccordionItem,
-    AccordionTrigger,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
 } from "@/components/ui/accordion";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 import { ProductSalesResponse } from "@/models/responses/company-stats.model";
 import { ColumnDef } from "@tanstack/react-table";
@@ -35,6 +35,8 @@ export const companyStatsColumns: ColumnDef<ProductSalesResponse>[] = [
                 <TableHeader>
                   <TableHead>Color</TableHead>
                   <TableHead>Size</TableHead>
+                  <TableHead>Sold Warehouse</TableHead>
+                  <TableHead>Sold Algiers</TableHead>
                   <TableHead>Sold Quantity</TableHead>
                 </TableHeader>
                 <TableBody>
@@ -42,6 +44,8 @@ export const companyStatsColumns: ColumnDef<ProductSalesResponse>[] = [
                     <TableRow key={variant.product_variant_id}>
                       <TableCell>{variant.color}</TableCell>
                       <TableCell>{variant.size}</TableCell>
+                      <TableCell>{variant.sold_warehouse}</TableCell>
+                      <TableCell>{variant.sold_algiers}</TableCell>
                       <TableCell>{variant.sold_quantity}</TableCell>
                     </TableRow>
                   ))}

--- a/src/models/responses/company-stats.model.ts
+++ b/src/models/responses/company-stats.model.ts
@@ -4,6 +4,8 @@ export interface ProductSalesResponse {
   name: string;
   variants: VariantSalesResponse[];
   total_sold_quantity: number;
+  total_sold_warehouse: number;
+  total_sold_algiers: number;
 }
 
 export interface VariantSalesResponse {
@@ -11,6 +13,8 @@ export interface VariantSalesResponse {
   color: string;
   size: number;
   sold_quantity: number;
+  sold_warehouse: number;
+  sold_algiers: number;
 }
 export interface PaginationMeta {
   total_items: number;


### PR DESCRIPTION

- Updated the company stats columns to include new fields for sold warehouse and sold Algiers, enhancing the data representation for product sales.
- Modified the ProductSalesResponse model to accommodate the new fields, improving the data structure for sales reporting.

These changes provide a more comprehensive view of product sales across different locations, improving data insights for users.