### PR TITLE
feat(franchise-dashboard): add statistics page and update menu

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -10,6 +10,7 @@ import DashboardLayout from "@/layouts/dashboard-layout";
 import MainLayout from "@/layouts/main-layout";
 import LoginPage from "@/pages/auth/login-page";
 import RegisterPage from "@/pages/auth/register-page";
+import CompanyFranchiseStatsPage from "@/pages/company-franchise-stats-page";
 import CompanyAlgiersSalesPage from "@/pages/dashboard/company/company-algiers-sales-page";
 import CompanyBillsPage from "@/pages/dashboard/company/company-bills-page";
 import CompanyControlPanelPage from "@/pages/dashboard/company/company-control-panel-page";
@@ -123,6 +124,7 @@ export default function AppRouter() {
                     path="inventory"
                     element={<CompanyFranchiseInventoryPage />}
                   />
+                  <Route path="statistics" element={<CompanyFranchiseStatsPage />} />
                 </Route>
               </Route>
               <Route path="warehouse" element={<WarehousePage />} />

--- a/src/components/feature-specific/company-franchise/franchise-stats/company-franchise-stats-app-bar.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-stats/company-franchise-stats-app-bar.tsx
@@ -1,0 +1,14 @@
+import { RootState } from "@/app/store";
+import AppBarBackButton from "@/components/common/app-bar-back-button";
+import { useSelector } from "react-redux";
+
+export default function () {
+  const franchise = useSelector((state: RootState) => state.franchise.franchise);
+  if (!franchise) return;  
+  return (
+    <div className="flex gap-4">
+      <AppBarBackButton destination="Menu" />
+      <h1 className="text-2xl font-bold">{franchise.name} &gt; Statistics</h1>
+    </div>
+  );
+}

--- a/src/components/feature-specific/company-franchise/franchise-stats/company-franchise-stats-body.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-stats/company-franchise-stats-body.tsx
@@ -1,0 +1,103 @@
+import { RootState } from "@/app/store";
+import { franchiseStatsColumns } from "@/components/feature-specific/company-franchise/franchise-stats/franchise-stats-columns";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DataTable } from "@/components/ui/data-table";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { getProductSalesByFranchise } from "@/services/product-service";
+import { useQuery } from "@tanstack/react-query";
+import { format, subMonths } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { useState } from "react";
+import { DateRange } from "react-day-picker";
+import { useSelector } from "react-redux";
+
+export default function () {
+  const franchise = useSelector(
+    (state: RootState) => state.franchise.franchise
+  );
+  if (!franchise) return;
+  const [date, setDate] = useState<DateRange | undefined>({
+    from: subMonths(new Date(), 1),
+    to: new Date(),
+  });
+  const [currentPage, setCurrentPage] = useState(0);
+  const { data } = useQuery({
+    queryKey: [
+      "product-sales",
+      franchise?.ID || 0,
+      date?.from || new Date(),
+      date?.to || new Date(),
+      currentPage,
+    ],
+    queryFn: () =>
+      getProductSalesByFranchise({
+        company_id: franchise?.ID || 0,
+        start_date: date?.from || new Date(),
+        end_date: date?.to || new Date(),
+        page: currentPage + 1,
+      }),
+    enabled: !!franchise?.ID && !!date?.from && !!date?.to,
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>Company Stats</span>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={cn(
+                  "justify-start text-left font-normal",
+                  !date && "text-muted-foreground"
+                )}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {date?.from ? (
+                  date.to ? (
+                    <>
+                      {format(date.from, "LLL dd, y")} -{" "}
+                      {format(date.to, "LLL dd, y")}
+                    </>
+                  ) : (
+                    format(date.from, "LLL dd, y")
+                  )
+                ) : (
+                  <span>Pick a date range</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="end">
+              <Calendar
+                initialFocus
+                mode="range"
+                defaultMonth={date?.from}
+                selected={date}
+                onSelect={setDate}
+                numberOfMonths={2}
+              />
+            </PopoverContent>
+          </Popover>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <DataTable
+          columns={franchiseStatsColumns}
+          data={data?.data?.products || []}
+          searchColumn="name"
+          paginationMeta={data?.data?.pagination}
+          onPageChange={(page) => setCurrentPage(page)}
+          currentPage={currentPage}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/feature-specific/company-franchise/franchise-stats/franchise-stats-columns.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-stats/franchise-stats-columns.tsx
@@ -1,0 +1,62 @@
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from "@/components/ui/accordion";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { ProductSalesResponse } from "@/models/responses/company-stats.model";
+import { ColumnDef } from "@tanstack/react-table";
+
+export const franchiseStatsColumns: ColumnDef<ProductSalesResponse>[] = [
+  {
+    header: "Product",
+    accessorKey: "name",
+    id: "name",
+  },
+
+  {
+    header: "Variants",
+    accessorKey: "variants",
+    cell: ({ row }) => {
+      return (
+        <Accordion type="single" collapsible>
+          <AccordionItem value={row.original.product_id.toString()}>
+            <AccordionTrigger>{row.original.name}</AccordionTrigger>
+            <AccordionContent>
+              <Table>
+                <TableHeader>
+                  <TableHead>Color</TableHead>
+                  <TableHead>Size</TableHead>
+
+                  <TableHead>Sold Quantity</TableHead>
+                </TableHeader>
+                <TableBody>
+                  {row.original.variants.map((variant) => (
+                    <TableRow key={variant.product_variant_id}>
+                      <TableCell>{variant.color}</TableCell>
+                      <TableCell>{variant.size}</TableCell>
+                      <TableCell>{variant.sold_quantity}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      );
+    },
+  },
+
+  {
+    header: "Total Sold Quantity",
+    accessorKey: "total_sold_quantity",
+  },
+];

--- a/src/components/feature-specific/franchise-dashboard/franchise-menu.tsx
+++ b/src/components/feature-specific/franchise-dashboard/franchise-menu.tsx
@@ -1,6 +1,6 @@
 import { RootState } from "@/app/store";
 import WideButton from "@/components/common/wide-button";
-import { Apple, ReceiptText, ShoppingCart, Warehouse } from "lucide-react";
+import { Apple, BarChart, ReceiptText, ShoppingCart, Warehouse } from "lucide-react";
 import { useSelector } from "react-redux";
 import FranchiseTile from "./franchise-tile";
 
@@ -8,12 +8,15 @@ export default function () {
   const franchise = useSelector(
     (state: RootState) => state.franchise.franchise
   );
+  const isAdministrator = useSelector(
+    (state: RootState) => state.franchise.isAdministrator
+  );
   if (!franchise) return;
   return (
     <div className="flex flex-col gap-4 items-center justify-center">
       <FranchiseTile franchise={franchise} />
       <div className="flex flex-wrap justify-center gap-4 self-center">
-        {quickMenu.map((item, index) => (
+        {quickMenu.filter(item => !isAdministrator ? item.label !== "Statistics" : true).map((item, index) => (
           <WideButton key={index} item={item} />
         ))}
       </div>
@@ -42,4 +45,9 @@ const quickMenu = [
     icon: Apple,
     href: "products",
   },
+  {
+    label: "Statistics",
+    icon: BarChart,
+    href: "statistics",
+  }
 ];

--- a/src/features/auth/franchise-slice.ts
+++ b/src/features/auth/franchise-slice.ts
@@ -7,10 +7,12 @@ interface FranchiseState {
   isAuthenticated: boolean;
   user?: FranchiseAdministrator;
   franchise?: Franchise
+  isAdministrator: boolean;
 }
 
 const initialState: FranchiseState = {
   isAuthenticated: false,
+  isAdministrator: false,
 };
 
 export const franchiseSlice = createSlice({
@@ -22,13 +24,20 @@ export const franchiseSlice = createSlice({
       state.user = action.payload;
       state.franchise = action.payload.franchise;
     },
+    loginAdministrator: (state, action: PayloadAction<FranchiseAdministrator>) => {
+      state.isAuthenticated = true;
+      state.user = action.payload;
+      state.franchise = action.payload.franchise;
+      state.isAdministrator = true;
+    },
     logout: (state) => {
       state.isAuthenticated = false;
       state.user = undefined;
       state.franchise = undefined;
+      state.isAdministrator = false;
     },
   },
 });
 
-export const { login, logout } = franchiseSlice.actions;
+export const { login, loginAdministrator, logout } = franchiseSlice.actions;
 export default franchiseSlice.reducer;

--- a/src/hooks/use-super-franchise.ts
+++ b/src/hooks/use-super-franchise.ts
@@ -1,6 +1,6 @@
 import { useAppDispatch } from "@/app/hooks";
 import { RootState } from "@/app/store";
-import { login } from "@/features/auth/franchise-slice";
+import { loginAdministrator } from "@/features/auth/franchise-slice";
 import { FranchiseAdministrator } from "@/models/data/administrator.model";
 import { APIError } from "@/models/responses/api-response.model";
 import { fetchUser } from "@/services/auth-service";
@@ -37,10 +37,10 @@ const useSuperFranchise = (franchiseID: number) => {
                 for (let company of companies) {
                     for (let franchise of (company?.franchises ?? [])) {
                         if (franchise.ID === franchiseID) {
-                            dispatch(login({
+                            dispatch(loginAdministrator({
                                 ID, CreatedAt, UpdatedAt, DeletedAt,
                                 full_name, email, administrator_id: ID,
-                                franchise_id: franchiseID, franchise
+                                franchise_id: franchiseID, franchise,
                             } as FranchiseAdministrator));
                             break;
                         }

--- a/src/pages/company-franchise-stats-page.tsx
+++ b/src/pages/company-franchise-stats-page.tsx
@@ -1,0 +1,10 @@
+import CompanyFranchiseStatsAppBar from "@/components/feature-specific/company-franchise/franchise-stats/company-franchise-stats-app-bar";
+import CompanyFranchiseStatsBody from "@/components/feature-specific/company-franchise/franchise-stats/company-franchise-stats-body";
+
+
+export default function() { 
+    return <div className="p-4">
+        <CompanyFranchiseStatsAppBar />
+        <CompanyFranchiseStatsBody />
+    </div>
+}

--- a/src/services/product-service.ts
+++ b/src/services/product-service.ts
@@ -238,3 +238,21 @@ export const getProductSales = async (data: SalesQuantityRequestSchema): Promise
     return apiResponse;
 }
 
+
+export const getProductSalesByFranchise = async (data: SalesQuantityRequestSchema): Promise<APIResponse<CompanyStatsResponse>> => {
+    const response = await fetch(`${baseUrl}/products/sales-quantities-franchise/${data.company_id}?startDate=${data.start_date.toISOString().split('T')[0]}&endDate=${data.end_date.toISOString().split('T')[0]}&page=${data.page}&limit=${data.limit??10}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${localStorage.getItem('token')}`
+        },
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to get product sales.");
+    }
+
+    const apiResponse: APIResponse<CompanyStatsResponse> = await response.json();
+    return apiResponse;
+}


### PR DESCRIPTION
- Introduced a new route for the CompanyFranchiseStatsPage, enhancing the franchise dashboard with statistical insights.
- Updated the franchise menu to include a "Statistics" button, conditionally displayed based on user role (administrator).
- Modified the franchise slice to manage administrator login state, improving user role handling.
- Added a new API service to fetch product sales by franchise, expanding data retrieval capabilities.

These changes enhance the franchise dashboard's functionality, providing users with valuable statistical data tailored to their roles.