### PR TITLE
feat(create-order-dialog): enhance shipping options and commune selection

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-4xl translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
@@ -107,14 +107,7 @@ const DialogDescription = React.forwardRef<
 DialogDescription.displayName = DialogPrimitive.Description.displayName
 
 export {
-  Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogTrigger,
-  DialogClose,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
+  Dialog, DialogClose,
+  DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger
 }
+

--- a/src/models/responses/yalidine.cache.ts
+++ b/src/models/responses/yalidine.cache.ts
@@ -1,0 +1,117 @@
+
+
+export interface ListResponse {
+  hasMore: boolean;
+  totalData: number;
+  data: any[];
+  links: {
+    self: string;
+    before: string | null;
+    after: string | null;
+  };
+}
+
+export interface Parcel {
+  tracking: string;
+  order_id: string;
+  firstname: string;
+  familyname: string;
+  contact_phone: string;
+  address: string;
+  is_stopdesk: number;
+  stopdesk_id: number;
+  stopdesk_name: string;
+  from_wilaya_id: number;
+  from_wilaya_name: string;
+  to_commune_id: number;
+  to_commune_name: string;
+  to_wilaya_id: number;
+  to_wilaya_name: string;
+  product_list: string;
+  price: number;
+  do_insurance: boolean;
+  declared_value: number;
+  delivery_fee: number;
+  freeshipping: number;
+  import_id: number;
+  date_creation: string;
+  date_expedition: string | null;
+  date_last_status: string;
+  last_status: string;
+  taxe_percentage: number;
+  taxe_from: number;
+  taxe_retour: number;
+  parcel_type: string;
+  parcel_sub_type: string | null;
+  has_receipt: boolean | null;
+  length: number | null;
+  width: number | null;
+  height: number | null;
+  weight: number | null;
+  has_recouvrement: number;
+  current_center_id: number;
+  current_center_name: string;
+  current_wilaya_id: number;
+  current_wilaya_name: string;
+  current_commune_id: number;
+  current_commune_name: string;
+  payment_status: string;
+  payment_id: string | null;
+  has_exchange: number;
+  product_to_collect: string | null;
+  label: string;
+  pin: string;
+  qr_text: string;
+}
+
+export interface ParcelListResponse extends ListResponse {
+  data: Parcel[];
+}
+
+export interface Center {
+  center_id: number;
+  name: string;
+  address: string;
+  gps: string;
+  commune_id: number;
+  commune_name: string;
+  wilaya_id: number;
+  wilaya_name: string;
+}
+
+export interface CenterListResponse extends ListResponse {
+  data: Center[];
+}
+
+export interface Commune {
+  id: number;
+  name: string;
+  wilaya_id: number;
+  wilaya_name: string;
+  has_stop_desk: number;
+  is_deliverable: number;
+  delivery_time_parcel: number;
+  delivery_time_payment: number;
+}
+
+export interface CommuneListResponse extends ListResponse {
+  data: Commune[];
+}
+
+export interface Wilaya {
+  id: number;
+  name: string;
+  zone: number;
+  is_deliverable: number;
+}
+
+export interface WilayaListResponse extends ListResponse {
+  data: Wilaya[];
+}
+
+export interface YalidineCache {
+  centers: Record<number, Center[]>;
+  communes: Record<number, Commune[]>;
+  wilayas: Record<number, Wilaya>;
+  last_refreshed: string;
+}

--- a/src/pages/dashboard/company/company-orders-page.tsx
+++ b/src/pages/dashboard/company/company-orders-page.tsx
@@ -4,6 +4,7 @@ import { companyOrdersColumns } from "@/components/feature-specific/orders/compa
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { useToast } from "@/hooks/use-toast";
+import { getCompanyInventory } from "@/services/inventory-service";
 import { assignOrders, shuffleOrders } from "@/services/order-service";
 import { getUsersByCompany } from "@/services/user-service";
 import { getWooCommerceOrders } from "@/services/woocommerce-service";
@@ -29,8 +30,11 @@ export default function CompanyOrdersPage() {
     queryKey: ["orders"],
     queryFn: () => getWooCommerceOrders(),
   });
-
-  // --- Shuffle Dialog State ---
+  useQuery({
+    queryKey: ["inventory", company.ID],
+    queryFn: () => getCompanyInventory(company.ID),
+    enabled: Boolean(company && company.ID),
+  });  // --- Shuffle Dialog State ---
   const [shuffleOpen, setShuffleOpen] = useState(false);
   const { data: usersData } = useUsersQuery({
     queryKey: ["users", company.ID],

--- a/src/services/order-service.ts
+++ b/src/services/order-service.ts
@@ -1,8 +1,8 @@
 import { baseUrl } from "@/app/constants";
 import { Order } from "@/models/data/order.model";
 import { APIResponse } from "@/models/responses/api-response.model";
+import { CommuneListResponse, YalidineCache } from "@/models/responses/yalidine.cache";
 import { CreateOrderSchema } from "@/schemas/order";
-
 
 export const createOrder = async (orderData: CreateOrderSchema): Promise<APIResponse<Order>> => {
   const response = await fetch(`${baseUrl}/orders`, {
@@ -59,4 +59,34 @@ export const assignOrders = async (data: { orders_ids: number[], user_id: number
 
   const assignedOrders: APIResponse<any> = await response.json();
   return assignedOrders;
+}
+
+export  const getYalidineCache = async (): Promise<APIResponse<YalidineCache>> => {
+  const response = await fetch(`${baseUrl}/woocommerce/cache`,{
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${localStorage.getItem("token")}`,
+    },
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || "Failed to get yalidine cache.");
+  }
+  const cache: APIResponse<YalidineCache> = await response.json();  
+  return cache;
+}
+
+export const getYalidineCommunes = async (state: number): Promise<APIResponse<CommuneListResponse>> => {
+  const response = await fetch(`${baseUrl}/woocommerce/communes/${state}`, {
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${localStorage.getItem("token")}`,
+    },
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || "Failed to get yalidine communes.");
+  }
+  const cache: APIResponse<CommuneListResponse> = await response.json();
+  return cache;
 }


### PR DESCRIPTION

- Introduced a shipping section in the CreateOrderDialog, allowing users to select a shipping provider and delivery type.
- Implemented dynamic fetching of communes based on the selected state and delivery type using react-query.
- Added state management for selected commune and center, improving user experience during order creation.
- Refactored the order items display for better readability and structure.

These changes enhance the order creation process by providing users with more flexible shipping options and clearer selection interfaces.