### PR TITLE
feat(create-order-dialog): enhance order creation with delivery options and pricing

### DIFF
--- a/src/models/responses/yalidine.cache.ts
+++ b/src/models/responses/yalidine.cache.ts
@@ -115,3 +115,23 @@ export interface YalidineCache {
   wilayas: Record<number, Wilaya>;
   last_refreshed: string;
 }
+
+export interface CommunePricing {
+  commune_id: number;
+  commune_name: string;
+  express_home: number | null;
+  express_desk: number | null;
+  economic_home: number | null;
+  economic_desk: number | null;
+}
+
+export interface PricingResponse {
+  from_wilaya_name: string;
+  to_wilaya_name: string;
+  zone: number;
+  retour_fee: number;
+  cod_percentage: number;
+  insurance_percentage: number;
+  oversize_fee: number;
+  per_commune: Record<string, CommunePricing>;
+}

--- a/src/services/order-service.ts
+++ b/src/services/order-service.ts
@@ -1,7 +1,7 @@
 import { baseUrl } from "@/app/constants";
 import { Order } from "@/models/data/order.model";
 import { APIResponse } from "@/models/responses/api-response.model";
-import { CenterListResponse, CommuneListResponse, YalidineCache } from "@/models/responses/yalidine.cache";
+import { CenterListResponse, CommuneListResponse, PricingResponse, YalidineCache } from "@/models/responses/yalidine.cache";
 import { CreateOrderSchema } from "@/schemas/order";
 
 export const createOrder = async (orderData: CreateOrderSchema): Promise<APIResponse<Order>> => {
@@ -105,3 +105,18 @@ export const getYalidineCenters = async (wilaya: number): Promise<APIResponse<Ce
   const cache: APIResponse<CenterListResponse> = await response.json();
   return cache;
 } 
+
+export const getYalidinePricing = async (fromWilaya: number, toWilaya: number): Promise<APIResponse<PricingResponse>> => {
+  const response = await fetch(`${baseUrl}/woocommerce/fees/${fromWilaya}/${toWilaya}`, {
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${localStorage.getItem("token")}`,
+    },
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || "Failed to get yalidine pricing.");
+  }
+  const cache: APIResponse<PricingResponse> = await response.json();
+  return cache;
+}


### PR DESCRIPTION


- Added functionality to fetch and display delivery companies based on the selected shipping provider in the CreateOrderDialog.
- Integrated Yalidine pricing retrieval, allowing users to view pricing details based on selected commune or center.
- Improved layout for better responsiveness and user experience, including adjustments to the order items display.
- Introduced new types for pricing responses to support the updated functionality.

These changes enhance the order creation process by providing users with more comprehensive delivery options and clearer pricing information.