### PR TITLE
feat(sales): add sales count queries for franchise and company sales

### DIFF
--- a/src/components/feature-specific/company-franchise/franchise-sales/franchise-sales-body.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-sales/franchise-sales-body.tsx
@@ -9,6 +9,7 @@ import {
   getCompanyFranchiseSales,
   getCompanyFranchiseSalesTotal,
 } from "@/services/franchise-service";
+import { getSalesCount } from "@/services/sale-service";
 import { useQuery } from "@tanstack/react-query";
 import { endOfDay, startOfDay } from "date-fns";
 import { useEffect, useState } from "react";
@@ -19,7 +20,7 @@ export default function () {
   const franchise = useSelector(
     (state: RootState) => state.franchise.franchise
   );
-  const {pathname} = useLocation(); 
+  const { pathname } = useLocation();
   const isModerator = pathname.includes("moderator");
 
   if (!franchise) return;
@@ -51,6 +52,31 @@ export default function () {
       getCompanyFranchiseSalesTotal(franchise.ID, dateRange.from, dateRange.to),
     enabled: !!dateRange.from && !!dateRange.to,
   });
+
+  // Query for today's sales count
+  const { data: salesCount } = useQuery({
+    queryKey: ["sales-count", franchise.ID, dateRange.from, dateRange.to],
+    queryFn: () =>
+      getSalesCount({
+        company_id: franchise.ID.toString(),
+        start_date: startOfDay(new Date()).toISOString(),
+        end_date: endOfDay(new Date()).toISOString(),
+        sale_type: "franchise",
+      }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
+
+  // Query for custom date range sales count
+  const {data: rangeSalesCount} = useQuery({
+    queryKey: ["sales-count-range", franchise.ID, dateRange.from, dateRange.to],
+    queryFn: () => getSalesCount({
+      company_id: franchise.ID.toString(),
+      start_date: dateRange.from.toISOString(),
+      end_date: dateRange.to.toISOString(),
+      sale_type: "franchise ",
+    }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
   const { data } = useQuery({
     queryKey: ["sales"],
     queryFn: () => getCompanyFranchiseSales(franchise.ID),
@@ -78,7 +104,20 @@ export default function () {
                 currency: "DZD",
               }).format(todayTotal?.data?.total_amount || 0)}
             </p>
-            
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">
+                  {salesCount?.data?.sales_count}
+                </span>{" "}
+                sales
+              </p>
+              <p>
+                <span className="font-bold">
+                  {salesCount?.data?.sale_items_count}
+                </span>{" "}
+                items
+              </p>
+            </div>
           </CardContent>
         </Card>
         <Card className={`${isModerator ? "hidden" : ""}`}>
@@ -129,6 +168,20 @@ export default function () {
                 currency: "DZD",
               }).format(rangeTotal?.data?.total_amount || 0)}
             </p>
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">
+                  {rangeSalesCount?.data?.sales_count}
+                </span>{" "}
+                sales
+              </p>
+              <p>
+                <span className="font-bold">
+                  {rangeSalesCount?.data?.sale_items_count}
+                </span>{" "}
+                items
+              </p>
+            </div>
           </CardContent>
         </Card>
         <Card className={`${isModerator ? "hidden" : ""}`}>
@@ -165,6 +218,7 @@ export default function () {
                 }).format(rangeTotal.data.total_benefit)}
               </p>
             )}
+         
           </CardContent>
         </Card>
       </div>

--- a/src/components/feature-specific/company-sales/algiers/company-sales-table.tsx
+++ b/src/components/feature-specific/company-sales/algiers/company-sales-table.tsx
@@ -4,7 +4,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { DatePickerWithRange } from "@/components/ui/date-range-picker";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
-import { getAlgiersSalesTotal, getCompanyAlgiersSales } from "@/services/sale-service";
+import { getAlgiersSalesTotal, getCompanyAlgiersSales, getSalesCount } from "@/services/sale-service";
 import { useQuery } from "@tanstack/react-query";
 import { endOfDay, startOfDay } from "date-fns";
 import { useEffect, useState } from "react";
@@ -34,6 +34,30 @@ export default function () {
     enabled: !!dateRange.from && !!dateRange.to,
   });
 
+  // Query for today's sales count
+  const { data: salesCount } = useQuery({
+    queryKey: ["sales-count", company.ID, dateRange.from, dateRange.to],
+    queryFn: () => getSalesCount({
+      company_id: company.ID.toString(),
+      start_date: startOfDay(new Date()).toISOString(),
+      end_date: endOfDay(new Date()).toISOString(),
+      sale_type: "algiers",
+    }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
+
+  // Query for custom date range sales count
+  const { data: rangeSalesCount } = useQuery({
+    queryKey: ["sales-count-range", company.ID, dateRange.from, dateRange.to],
+    queryFn: () => getSalesCount({
+      company_id: company.ID.toString(),
+      start_date: dateRange.from.toISOString(),
+      end_date: dateRange.to.toISOString(),
+      sale_type: "algiers",
+    }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
+  
   const { data } = useQuery({
     queryKey: ["sales", "algiers"],
     queryFn: () => getCompanyAlgiersSales(company.ID),
@@ -70,6 +94,14 @@ export default function () {
                 }).format(todayTotal.data.total_benefit)}
               </p>
             )}
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">{salesCount?.data?.sales_count}</span> sales
+              </p>
+              <p>
+                <span className="font-bold">{salesCount?.data?.sale_items_count}</span> items
+              </p>
+            </div>
           </CardContent>
         </Card>
 
@@ -107,6 +139,14 @@ export default function () {
                 }).format(rangeTotal.data.total_benefit)}
               </p>
             )}
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">{rangeSalesCount?.data?.sales_count}</span> sales
+              </p>
+              <p>
+                <span className="font-bold">{rangeSalesCount?.data?.sale_items_count}</span> items
+              </p>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/feature-specific/company-sales/company-sales-table.tsx
+++ b/src/components/feature-specific/company-sales/company-sales-table.tsx
@@ -4,7 +4,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { DatePickerWithRange } from "@/components/ui/date-range-picker";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
-import { getCompanySales, getSalesTotal } from "@/services/sale-service";
+import { getCompanySales, getSalesCount, getSalesTotal } from "@/services/sale-service";
 import { useQuery } from "@tanstack/react-query";
 import { endOfDay, startOfDay } from "date-fns";
 import { useEffect, useState } from "react";
@@ -31,6 +31,30 @@ export default function () {
   const { data: rangeTotal } = useQuery({
     queryKey: ["sales-total-range", company.ID, dateRange.from, dateRange.to],
     queryFn: () => getSalesTotal(company.ID, dateRange.from, dateRange.to),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
+
+  // Query for today's sales count
+  const { data: salesCount } = useQuery({
+    queryKey: ["sales-count", company.ID, dateRange.from, dateRange.to],
+    queryFn: () => getSalesCount({
+      company_id: company.ID.toString(),
+      start_date: startOfDay(new Date()).toISOString(),
+      end_date: endOfDay(new Date()).toISOString(),
+      sale_type: "warehouse",
+    }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
+
+  // Query for custom date range sales count
+  const { data: rangeSalesCount } = useQuery({
+    queryKey: ["sales-count-range", company.ID, dateRange.from, dateRange.to],
+    queryFn: () => getSalesCount({
+      company_id: company.ID.toString(),
+      start_date: dateRange.from.toISOString(),
+      end_date: dateRange.to.toISOString(),
+      sale_type: "warehouse",
+    }),
     enabled: !!dateRange.from && !!dateRange.to,
   });
 
@@ -70,6 +94,14 @@ export default function () {
                 }).format(todayTotal.data.total_benefit)}
               </p>
             )}
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">{salesCount?.data?.sales_count}</span> sales
+              </p>
+              <p>
+                <span className="font-bold">{salesCount?.data?.sale_items_count}</span> items
+              </p>
+            </div>
           </CardContent>
         </Card>
 
@@ -107,6 +139,14 @@ export default function () {
                 }).format(rangeTotal.data.total_benefit)}
               </p>
             )}
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">{rangeSalesCount?.data?.sales_count}</span> sales
+              </p>
+              <p>
+                <span className="font-bold">{rangeSalesCount?.data?.sale_items_count}</span> items
+              </p>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/feature-specific/franchise-sales/franchise-sales-body.tsx
+++ b/src/components/feature-specific/franchise-sales/franchise-sales-body.tsx
@@ -6,6 +6,7 @@ import { DatePickerWithRange } from "@/components/ui/date-range-picker";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 import { getFranchiseSales, getFranchiseSalesTotal } from "@/services/franchise-service";
+import { getSalesCount } from "@/services/sale-service";
 import { useQuery } from "@tanstack/react-query";
 import { endOfDay, startOfDay } from "date-fns";
 import { useEffect, useState } from "react";
@@ -33,6 +34,33 @@ export default function () {
     queryFn: () => getFranchiseSalesTotal(franchise.ID, dateRange.from, dateRange.to),
     enabled: !!dateRange.from && !!dateRange.to,
   });
+
+  
+  // Query for today's sales count
+  const { data: salesCount } = useQuery({
+    queryKey: ["sales-count", franchise.ID, dateRange.from, dateRange.to],
+    queryFn: () =>
+      getSalesCount({
+        company_id: franchise.ID.toString(),
+        start_date: startOfDay(new Date()).toISOString(),
+        end_date: endOfDay(new Date()).toISOString(),
+        sale_type: "franchise",
+      }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  });
+
+  // Query for custom date range sales count
+  const { data: rangeSalesCount } = useQuery({
+    queryKey: ["sales-count-range", franchise.ID, dateRange.from, dateRange.to],
+    queryFn: () =>
+      getSalesCount({
+        company_id: franchise.ID.toString(),
+        start_date: dateRange.from.toISOString(),
+        end_date: dateRange.to.toISOString(),
+        sale_type: "franchise ",
+      }),
+    enabled: !!dateRange.from && !!dateRange.to,
+  }); 
 
   const { data } = useQuery({
     queryKey: ["sales"],
@@ -74,6 +102,20 @@ export default function () {
                 currency: "DZD",
               }).format((todayTotal?.data?.total_amount || 0) - (todayTotal?.data?.total_franchise_price || 0))}
             </p>
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">
+                  {salesCount?.data?.sales_count}
+                </span>{" "}
+                sales
+              </p>
+              <p>
+                <span className="font-bold">
+                  {salesCount?.data?.sale_items_count}
+                </span>{" "}
+                items
+              </p>
+            </div>
           </CardContent>
         </Card>
         <Card>
@@ -101,6 +143,20 @@ export default function () {
                 currency: "DZD",
               }).format(rangeTotal?.data?.total_amount || 0)}
             </p>
+            <div className="text-lg text-white flex items-center gap-2">
+              <p>
+                <span className="font-bold">
+                  {rangeSalesCount?.data?.sales_count}
+                </span>{" "}
+                sales
+              </p>
+              <p>
+                <span className="font-bold">
+                  {rangeSalesCount?.data?.sale_items_count}
+                </span>{" "}
+                items
+              </p>
+            </div>
           </CardContent>
         </Card>
         <Card>

--- a/src/models/responses/sales-count.model.ts
+++ b/src/models/responses/sales-count.model.ts
@@ -1,0 +1,9 @@
+
+
+
+export interface SalesCountResponse {
+    sales_count: number;
+    sale_items_count: number;
+    start_date: string;
+    end_date: string;
+}

--- a/src/services/sale-service.ts
+++ b/src/services/sale-service.ts
@@ -1,6 +1,7 @@
 import { baseUrl } from "@/app/constants";
 import { Sale } from "@/models/data/sale.model";
 import { APIResponse } from "@/models/responses/api-response.model";
+import { SalesCountResponse } from "@/models/responses/sales-count.model";
 import { CreateSaleSchema } from "@/schemas/sale";
 
 export const createCompanySale = async (data: CreateSaleSchema): Promise<APIResponse<Sale>> => {
@@ -176,4 +177,41 @@ export const downloadAndPrintPDF = async (saleID: number): Promise<void> => {
     } else {
         throw new Error("Failed to open print window.");
     }
+}
+
+export const getSalesCount = async (params: {
+    company_id?: string;
+    franchise_id?: string;
+    start_date: string;
+    end_date: string;
+    sale_type?: string;
+}): Promise<APIResponse<SalesCountResponse>> => {
+    const queryParams = new URLSearchParams();
+    
+    if (params.company_id) {
+        queryParams.append('company_id', params.company_id);
+    }
+    if (params.franchise_id) {
+        queryParams.append('franchise_id', params.franchise_id);
+    }
+    queryParams.append('start_date', params.start_date);
+    queryParams.append('end_date', params.end_date);
+    if (params.sale_type) {
+        queryParams.append('sale_type', params.sale_type);
+    }
+
+    const response = await fetch(`${baseUrl}/sales/count?${queryParams.toString()}`, {
+        method: 'GET',
+        headers: {
+            'Authorization': `Bearer ${localStorage.getItem('token')}`
+        }
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to get sales count.");
+    }
+
+    const apiResponse: APIResponse<SalesCountResponse> = await response.json();
+    return apiResponse;
 }


### PR DESCRIPTION
- Integrated sales count queries for today's sales and custom date ranges in franchise and company sales components.
- Updated the sales display to show the number of sales and items sold, enhancing visibility of sales performance.
- Added a new `getSalesCount` function in the sale-service to fetch sales count data based on company or franchise ID and date range.

These changes improve the sales tracking capabilities by providing real-time sales metrics for better decision-making.