### PR TITLE
fix(franchise-sales): correct query parameter from company_id to franchise_id

### DIFF
--- a/src/components/feature-specific/company-franchise/franchise-sales/franchise-sales-body.tsx
+++ b/src/components/feature-specific/company-franchise/franchise-sales/franchise-sales-body.tsx
@@ -58,7 +58,7 @@ export default function () {
     queryKey: ["sales-count", franchise.ID, dateRange.from, dateRange.to],
     queryFn: () =>
       getSalesCount({
-        company_id: franchise.ID.toString(),
+        franchise_id: franchise.ID.toString(),
         start_date: startOfDay(new Date()).toISOString(),
         end_date: endOfDay(new Date()).toISOString(),
         sale_type: "franchise",
@@ -70,10 +70,9 @@ export default function () {
   const {data: rangeSalesCount} = useQuery({
     queryKey: ["sales-count-range", franchise.ID, dateRange.from, dateRange.to],
     queryFn: () => getSalesCount({
-      company_id: franchise.ID.toString(),
+      franchise_id: franchise.ID.toString(),
       start_date: dateRange.from.toISOString(),
       end_date: dateRange.to.toISOString(),
-      sale_type: "franchise ",
     }),
     enabled: !!dateRange.from && !!dateRange.to,
   });

--- a/src/components/feature-specific/franchise-sales/franchise-sales-body.tsx
+++ b/src/components/feature-specific/franchise-sales/franchise-sales-body.tsx
@@ -41,7 +41,7 @@ export default function () {
     queryKey: ["sales-count", franchise.ID, dateRange.from, dateRange.to],
     queryFn: () =>
       getSalesCount({
-        company_id: franchise.ID.toString(),
+        franchise_id: franchise.ID.toString(),
         start_date: startOfDay(new Date()).toISOString(),
         end_date: endOfDay(new Date()).toISOString(),
         sale_type: "franchise",
@@ -54,7 +54,7 @@ export default function () {
     queryKey: ["sales-count-range", franchise.ID, dateRange.from, dateRange.to],
     queryFn: () =>
       getSalesCount({
-        company_id: franchise.ID.toString(),
+        franchise_id: franchise.ID.toString(),
         start_date: dateRange.from.toISOString(),
         end_date: dateRange.to.toISOString(),
         sale_type: "franchise ",


### PR DESCRIPTION

- Updated the sales count query parameters in the franchise sales component to use franchise_id instead of company_id for accurate data retrieval.
- Ensured consistency in the query function for both today's sales and custom date ranges.

This change improves the accuracy of sales data fetching for franchise sales.