### PR TITLE
feat(affiliate-props): add shopify_link to affiliate properties and update related components

### DIFF
--- a/src/components/feature-specific/company-products/set-affiliate-props-dialog.tsx
+++ b/src/components/feature-specific/company-products/set-affiliate-props-dialog.tsx
@@ -30,7 +30,8 @@ import * as z from "zod";
 const affiliatePropSchema = z.object({
   name: z.string().min(1, "Name is required"),
   creatives_link: z.string().url("Must be a valid URL").optional().or(z.literal("")),
-  product_link: z.string().url("Must be a valid URL"),
+  product_link: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+  shopify_link: z.string().url("Must be a valid URL").optional().or(z.literal("")),
   commission: z.coerce.number().int().min(0, "Commission cannot be negative"),
 });
 
@@ -67,6 +68,7 @@ export function SetAffiliatePropsDialog({
         creatives_link: existingProp?.creatives_link || "",
         product_link: existingProp?.product_link || "",
         commission: existingProp?.commission || 0,
+        shopify_link: existingProp?.shopify_link || "",
       };
     }),
   };
@@ -158,7 +160,23 @@ export function SetAffiliatePropsDialog({
                     name={`affiliate_props.${index}.product_link`}
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Product Link</FormLabel>
+                        <FormLabel>WooCommerce Link</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://example.com/product"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`affiliate_props.${index}.shopify_link`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Shopify Link</FormLabel>
                         <FormControl>
                           <Input
                             placeholder="https://example.com/product"

--- a/src/models/data/product.model.ts
+++ b/src/models/data/product.model.ts
@@ -47,6 +47,7 @@ export interface AffiliateProp {
     product?: Product;
     images?: ProductImage[];
     product_link: string;
+    shopify_link: string;
     name: string;
     creatives_link: string;
     commission: number;

--- a/src/pages/affiliate/dashboard/affiliate-my-links-page.tsx
+++ b/src/pages/affiliate/dashboard/affiliate-my-links-page.tsx
@@ -46,7 +46,7 @@ export default function AffiliateMyLinksPage() {
       return;
     }
 
-    const linkWithRef = `${affiliateProp.product_link}?ref=${affiliate.slug}`;
+    const linkWithRef = `${affiliateProp.shopify_link}?ref=${affiliate.slug}`;
 
     try {
       await navigator.clipboard.writeText(linkWithRef);


### PR DESCRIPTION


- Made product_link optional in the affiliate properties schema.
- Introduced shopify_link to the AffiliateProp interface and updated the SetAffiliatePropsDialog to include a new input field for Shopify links.
- Updated the AffiliateMyLinksPage to generate links using the shopify_link instead of product_link, ensuring correct referral link generation.