### PR TITLE
feat(company-missing-variants): enhance exit bill creation with additional items support

### DIFF
--- a/src/components/feature-specific/company-missing-variants/company-missing-variants-app-bar.tsx
+++ b/src/components/feature-specific/company-missing-variants/company-missing-variants-app-bar.tsx
@@ -2,18 +2,20 @@ import { RootState } from "@/app/store";
 import AppBarBackButton from "@/components/common/app-bar-back-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Package } from "lucide-react";
+import { Package, Plus } from "lucide-react";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 
 interface CompanyMissingVariantsAppBarProps {
   onCreateExitBill: () => void;
+  onCreateAdditionalItemsExitBill: () => void;
   selectedCount: number;
   selectedFranchiseId?: number;
 }
 
 export default function CompanyMissingVariantsAppBar({ 
   onCreateExitBill, 
+  onCreateAdditionalItemsExitBill,
   selectedCount, 
   selectedFranchiseId 
 }: CompanyMissingVariantsAppBarProps) {
@@ -40,6 +42,15 @@ export default function CompanyMissingVariantsAppBar({
             {selectedCount} selected
           </Badge>
         )}
+        
+        <Button 
+          onClick={onCreateAdditionalItemsExitBill}
+          variant="outline"
+          className="flex items-center gap-2"
+        >
+          <Plus className="h-4 w-4" />
+          Add Items Only
+        </Button>
         
         <Button 
           onClick={onCreateExitBill}

--- a/src/components/feature-specific/company-missing-variants/create-exit-bill-dialog.tsx
+++ b/src/components/feature-specific/company-missing-variants/create-exit-bill-dialog.tsx
@@ -1,6 +1,7 @@
 import { RootState } from "@/app/store";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
     Dialog,
     DialogContent,
@@ -23,12 +24,15 @@ import { useToast } from "@/hooks/use-toast";
 import { MissingVariantRequestResponse } from "@/models/data/missing-variant.model";
 import { CreateExitBillFromMissingVariantsSchema, createExitBillFromMissingVariantsSchema } from "@/schemas/missing-variant";
 import { createExitBillFromMissingVariants } from "@/services/missing-variants-service";
+import { getAllProductsWithVariantsByCompany } from "@/services/product-service";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Trash2 } from "lucide-react";
 import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { useFieldArray, useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
+import { ProductVariantCombobox } from "../company-products/product-variant-combobox";
 
 interface CreateExitBillDialogProps {
   open: boolean;
@@ -55,18 +59,40 @@ export default function CreateExitBillDialog({
     company = useSelector((state: RootState) => state.user.company);
   }
 
+  // Get all products with variants for the company
+  const { data: productsData } = useQuery({
+    queryKey: ["products", company?.ID],
+    queryFn: () => getAllProductsWithVariantsByCompany(company?.ID ?? 0),
+    enabled: !!company,
+  });
+
+  // Flatten all variants from all products
+  const allVariants = productsData?.data?.flatMap(product => 
+    product.product_variants?.map(variant => ({
+      ...variant,
+      product_name: product.name,
+    })) || []
+  ) || [];
+
   const form = useForm<CreateExitBillFromMissingVariantsSchema>({
     resolver: zodResolver(createExitBillFromMissingVariantsSchema),
     defaultValues: {
       franchise_id: franchiseId,
       company_id: companyId,
-      request_ids: selectedRequests.map(req => req.id),
+      request_ids: selectedRequests.length > 0 ? selectedRequests.map(req => req.id) : undefined,
       comment: "",
-      quantity_adjustments: selectedRequests.map(req => ({
+      quantity_adjustments: selectedRequests.length > 0 ? selectedRequests.map(req => ({
         request_id: req.id,
         quantity: req.requested_quantity,
-      })),
+      })) : undefined,
+      additional_items: [],
     },
+  });
+
+  // Field array for additional items
+  const { fields: additionalItemsFields, append: appendAdditionalItem, remove: removeAdditionalItem } = useFieldArray({
+    control: form.control,
+    name: "additional_items",
   });
 
   console.log('Form initialized with:', {
@@ -85,21 +111,23 @@ export default function CreateExitBillDialog({
       form.reset({
         franchise_id: franchiseId,
         company_id: companyId,
-        request_ids: selectedRequests.map(req => req.id),
+        request_ids: selectedRequests.length > 0 ? selectedRequests.map(req => req.id) : undefined,
         comment: "",
-        quantity_adjustments: selectedRequests.map(req => ({
+        quantity_adjustments: selectedRequests.length > 0 ? selectedRequests.map(req => ({
           request_id: req.id,
           quantity: req.requested_quantity,
-        })),
+        })) : undefined,
+        additional_items: [],
       });
       console.log('Form reset with values:', {
         franchise_id: franchiseId,
         company_id: companyId,
-        request_ids: selectedRequests.map(req => req.id),
-        quantity_adjustments: selectedRequests.map(req => ({
+        request_ids: selectedRequests.length > 0 ? selectedRequests.map(req => req.id) : undefined,
+        quantity_adjustments: selectedRequests.length > 0 ? selectedRequests.map(req => ({
           request_id: req.id,
           quantity: req.requested_quantity,
-        }))
+        })) : undefined,
+        additional_items: []
       });
     }
   }, [open, franchiseId, companyId, selectedRequests, form]);
@@ -108,9 +136,22 @@ export default function CreateExitBillDialog({
     mutationFn: createExitBillFromMissingVariants,
     onSuccess: (data) => {
       console.log('Success:', data);
+      const response = data.data;
+      let message = `Exit bill created successfully with ${response.total_bill_items} items.`;
+      
+      if (response.fulfilled_requests > 0) {
+        message += ` ${response.fulfilled_requests} requests fully fulfilled.`;
+      }
+      if (response.partially_fulfilled_requests > 0) {
+        message += ` ${response.partially_fulfilled_requests} requests partially fulfilled.`;
+      }
+      if (response.additional_items_processed > 0) {
+        message += ` ${response.additional_items_processed} additional items processed.`;
+      }
+      
       toast({
         title: "Success",
-        description: `Exit bill created successfully. ${data.data.fulfilled_requests} requests fulfilled.`,
+        description: message,
       });
       queryClient.invalidateQueries({ queryKey: ["company-missing-variants"] });
       queryClient.invalidateQueries({ queryKey: ["exit_bills"] });
@@ -134,12 +175,27 @@ export default function CreateExitBillDialog({
   };
 
   const watchedQuantityAdjustments = form.watch("quantity_adjustments");
-  const totalQuantity = watchedQuantityAdjustments 
+  const watchedAdditionalItems = form.watch("additional_items");
+  
+  const missingVariantsQuantity = watchedQuantityAdjustments 
     ? watchedQuantityAdjustments
         .filter(adj => adj.quantity > 0)
         .reduce((sum, adj) => sum + adj.quantity, 0)
     : selectedRequests.reduce((sum, req) => sum + req.requested_quantity, 0);
-  const franchiseName = selectedRequests[0]?.franchise_name || "Unknown";
+  
+  const additionalItemsQuantity = watchedAdditionalItems
+    ? watchedAdditionalItems.reduce((sum, item) => sum + (item.quantity || 0), 0)
+    : 0;
+  
+  const totalQuantity = missingVariantsQuantity + additionalItemsQuantity;
+  
+  // Get franchise name from selected requests or find it from products data
+  let franchiseName = selectedRequests[0]?.franchise_name || "Unknown";
+  if (franchiseName === "Unknown" && franchiseId && productsData?.data) {
+    // For additional items only, we might need to get franchise name from API
+    // For now, we'll show the franchise ID
+    franchiseName = `Franchise ${franchiseId}`;
+  }
 
   // Debug form state
   console.log('Form state:', {
@@ -151,19 +207,22 @@ export default function CreateExitBillDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create Exit Bill</DialogTitle>
           <DialogDescription>
-            Create an exit bill to fulfill missing variant requests for {franchiseName}.
+            {selectedRequests.length > 0 
+              ? `Create an exit bill to fulfill missing variant requests for ${franchiseName}.`
+              : `Create an exit bill with additional items for ${franchiseName}.`
+            }
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           {/* Summary */}
           <div className="bg-muted p-4 rounded-lg">
-            <h3 className="font-semibold mb-2">Request Summary</h3>
-            <div className="grid grid-cols-2 gap-4 text-sm">
+            <h3 className="font-semibold mb-2">Exit Bill Summary</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
               <div>
                 <span className="font-medium">Franchise:</span>
                 <Badge variant="outline" className="ml-2">{franchiseName}</Badge>
@@ -173,65 +232,179 @@ export default function CreateExitBillDialog({
                 <span className="ml-2">{totalQuantity}</span>
               </div>
               <div>
-                <span className="font-medium">Selected Requests:</span>
+                <span className="font-medium">Missing Requests:</span>
                 <span className="ml-2">{selectedRequests.length}</span>
               </div>
+              <div>
+                <span className="font-medium">Additional Items:</span>
+                <span className="ml-2">{additionalItemsFields.length}</span>
+              </div>
             </div>
+            {(missingVariantsQuantity > 0 || additionalItemsQuantity > 0) && (
+              <div className="mt-2 pt-2 border-t">
+                <div className="grid grid-cols-2 gap-4 text-xs text-muted-foreground">
+                  <div>Missing Variants: {missingVariantsQuantity} items</div>
+                  <div>Additional Items: {additionalItemsQuantity} items</div>
+                </div>
+              </div>
+            )}
           </div>
 
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
               {/* Selected Items with Editable Quantities */}
-              <div className="max-h-60 overflow-y-auto">
-                <h3 className="font-semibold mb-2">Selected Items</h3>
-                <div className="space-y-3">
-                  {selectedRequests.map((request, index) => {
-                    const currentQuantity = watchedQuantityAdjustments?.[index]?.quantity ?? request.requested_quantity;
-                    const isExcluded = currentQuantity === 0;
-                    
-                    return (
-                      <div key={request.id} className={`p-3 border rounded-lg ${isExcluded ? 'opacity-50 bg-muted' : ''}`}>
-                        <div className="flex justify-between items-start mb-2">
-                          <div>
-                            <span className="font-medium">{request.product_name}</span>
-                            <span className="text-gray-500 ml-2">
-                              {request.product_variant_color} (Size {request.product_variant_size})
-                            </span>
-                            {isExcluded && (
-                              <Badge variant="secondary" className="ml-2 text-xs">
-                                Excluded
+              {selectedRequests.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg">Missing Variant Requests</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="max-h-60 overflow-y-auto space-y-3">
+                      {selectedRequests.map((request, index) => {
+                        const currentQuantity = watchedQuantityAdjustments?.[index]?.quantity ?? request.requested_quantity;
+                        const isExcluded = currentQuantity === 0;
+                        
+                        return (
+                          <div key={request.id} className={`p-3 border rounded-lg ${isExcluded ? 'opacity-50 bg-muted' : ''}`}>
+                            <div className="flex justify-between items-start mb-2">
+                              <div>
+                                <span className="font-medium">{request.product_name}</span>
+                                <span className="text-gray-500 ml-2">
+                                  {request.product_variant_color} (Size {request.product_variant_size})
+                                </span>
+                                {isExcluded && (
+                                  <Badge variant="secondary" className="ml-2 text-xs">
+                                    Excluded
+                                  </Badge>
+                                )}
+                              </div>
+                              <Badge variant="outline" className="text-xs">
+                                Original: {request.requested_quantity}
                               </Badge>
+                            </div>
+                            <FormField
+                              control={form.control}
+                              name={`quantity_adjustments.${index}.quantity`}
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="text-sm">Quantity to fulfill</FormLabel>
+                                  <FormControl>
+                                    <Input
+                                      type="number"
+                                      min="0"
+                                      max={request.requested_quantity}
+                                      placeholder={`Max: ${request.requested_quantity}`}
+                                      {...field}
+                                      onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
+                                    />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Additional Items Section */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg flex items-center justify-between">
+                    Additional Items
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => appendAdditionalItem({ product_variant_id: 0, quantity: 1 })}
+                    >
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Item
+                    </Button>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {additionalItemsFields.length === 0 ? (
+                    <p className="text-muted-foreground text-sm">No additional items. Click "Add Item" to include items not related to missing variant requests.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {additionalItemsFields.map((field, index) => {
+                        const selectedVariantId = form.watch(`additional_items.${index}.product_variant_id`);
+                        const selectedVariant = allVariants.find(v => v.ID === selectedVariantId);
+                        
+                        return (
+                          <div key={field.id} className="p-4 border rounded-lg">
+                            <div className="flex items-center justify-between mb-3">
+                              <h4 className="font-medium">Item {index + 1}</h4>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => removeAdditionalItem(index)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                            
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                              <FormField
+                                control={form.control}
+                                name={`additional_items.${index}.product_variant_id`}
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Product Variant</FormLabel>
+                                    <FormControl>
+                                      <ProductVariantCombobox
+                                        value={field.value}
+                                        onChange={field.onChange}
+                                        variants={allVariants}
+                                        placeholder="Select product variant..."
+                                      />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                              
+                              <FormField
+                                control={form.control}
+                                name={`additional_items.${index}.quantity`}
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Quantity</FormLabel>
+                                    <FormControl>
+                                      <Input
+                                        type="number"
+                                        min="1"
+                                        placeholder="Enter quantity"
+                                        {...field}
+                                        onChange={(e) => field.onChange(parseInt(e.target.value) || 1)}
+                                      />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            </div>
+                            
+                            {selectedVariant && (
+                              <div className="mt-2 p-2 bg-muted rounded text-sm">
+                                <span className="font-medium">{selectedVariant.product_name}</span>
+                                <span className="text-muted-foreground ml-2">
+                                  {selectedVariant.color} (Size {selectedVariant.size})
+                                </span>
+                              </div>
                             )}
                           </div>
-                          <Badge variant="outline" className="text-xs">
-                            Original: {request.requested_quantity}
-                          </Badge>
-                        </div>
-                        <FormField
-                          control={form.control}
-                          name={`quantity_adjustments.${index}.quantity`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel className="text-sm">Quantity to fulfill</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min="0"
-                                  max={request.requested_quantity}
-                                  placeholder={`Max: ${request.requested_quantity}`}
-                                  {...field}
-                                  onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
 
               <FormField
                 control={form.control}

--- a/src/models/data/missing-variant.model.ts
+++ b/src/models/data/missing-variant.model.ts
@@ -107,4 +107,8 @@ export interface CreateExitBillFromMissingVariantsResponse {
     }>;
   };
   fulfilled_requests: number;
+  partially_fulfilled_requests: number;
+  total_processed_requests: number;
+  additional_items_processed: number;
+  total_bill_items: number;
 }

--- a/src/pages/dashboard/company/company-missing-variants-page.tsx
+++ b/src/pages/dashboard/company/company-missing-variants-page.tsx
@@ -2,7 +2,12 @@ import { RootState } from "@/app/store";
 import CompanyMissingVariantsAppBar from "@/components/feature-specific/company-missing-variants/company-missing-variants-app-bar";
 import CompanyMissingVariantsBody from "@/components/feature-specific/company-missing-variants/company-missing-variants-body";
 import CreateExitBillDialog from "@/components/feature-specific/company-missing-variants/create-exit-bill-dialog";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { MissingVariantRequestResponse } from "@/models/data/missing-variant.model";
+import { getMyCompanyFranchises } from "@/services/franchise-service";
+import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
@@ -11,6 +16,9 @@ export default function CompanyMissingVariantsPage() {
   const [createExitBillOpen, setCreateExitBillOpen] = useState(false);
   const [selectedRequests, setSelectedRequests] = useState<MissingVariantRequestResponse[]>([]);
   const [selectedFranchiseId, setSelectedFranchiseId] = useState<number | undefined>();
+  const [isAdditionalItemsOnly, setIsAdditionalItemsOnly] = useState(false);
+  const [franchiseSelectorOpen, setFranchiseSelectorOpen] = useState(false);
+  const [tempFranchiseId, setTempFranchiseId] = useState<number | undefined>();
 
   let company = useSelector((state: RootState) => state.company.company);
   const { pathname } = useLocation();
@@ -18,8 +26,31 @@ export default function CompanyMissingVariantsPage() {
     company = useSelector((state: RootState) => state.user.company);
   }
 
+  // Get company franchises
+  const { data: franchisesData } = useQuery({
+    queryKey: ["company-franchises", company?.ID],
+    queryFn: () => getMyCompanyFranchises(company?.ID ?? 0),
+    enabled: !!company,
+  });
+
   const handleCreateExitBill = () => {
     if (selectedRequests.length > 0 && selectedFranchiseId && company) {
+      setIsAdditionalItemsOnly(false);
+      setCreateExitBillOpen(true);
+    }
+  };
+
+  const handleCreateAdditionalItemsExitBill = () => {
+    if (company) {
+      setIsAdditionalItemsOnly(true);
+      setFranchiseSelectorOpen(true);
+    }
+  };
+
+  const handleFranchiseSelected = () => {
+    if (tempFranchiseId) {
+      setSelectedFranchiseId(tempFranchiseId);
+      setFranchiseSelectorOpen(false);
       setCreateExitBillOpen(true);
     }
   };
@@ -44,6 +75,7 @@ export default function CompanyMissingVariantsPage() {
     <div className="p-4 space-y-4">
       <CompanyMissingVariantsAppBar 
         onCreateExitBill={handleCreateExitBill}
+        onCreateAdditionalItemsExitBill={handleCreateAdditionalItemsExitBill}
         selectedCount={selectedRequests.length}
         selectedFranchiseId={selectedFranchiseId}
       />
@@ -53,10 +85,55 @@ export default function CompanyMissingVariantsPage() {
       <CreateExitBillDialog 
         open={createExitBillOpen} 
         onOpenChange={setCreateExitBillOpen}
-        selectedRequests={selectedRequests}
+        selectedRequests={isAdditionalItemsOnly ? [] : selectedRequests}
         franchiseId={selectedFranchiseId || 0}
         companyId={company.ID}
       />
+
+      {/* Franchise Selector Dialog */}
+      <Dialog open={franchiseSelectorOpen} onOpenChange={setFranchiseSelectorOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Select Franchise</DialogTitle>
+            <DialogDescription>
+              Choose a franchise to create an exit bill with additional items.
+            </DialogDescription>
+          </DialogHeader>
+          
+          <div className="space-y-4">
+            <Select 
+              value={tempFranchiseId?.toString()} 
+              onValueChange={(value) => setTempFranchiseId(parseInt(value))}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a franchise..." />
+              </SelectTrigger>
+              <SelectContent>
+                {franchisesData?.data?.map((franchise) => (
+                  <SelectItem key={franchise.ID} value={franchise.ID.toString()}>
+                    {franchise.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setFranchiseSelectorOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleFranchiseSelected}
+              disabled={!tempFranchiseId}
+            >
+              Continue
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/schemas/missing-variant.ts
+++ b/src/schemas/missing-variant.ts
@@ -14,13 +14,25 @@ export const updateMissingVariantRequestSchema = z.object({
 export const createExitBillFromMissingVariantsSchema = z.object({
   franchise_id: z.number().min(1, "Franchise ID is required"),
   company_id: z.number().min(1, "Company ID is required"),
-  request_ids: z.array(z.number().min(1)).min(1, "At least one request ID is required"),
+  request_ids: z.array(z.number().min(1)).optional(),
   comment: z.string().optional(),
   // Updated to allow 0 quantities (items with 0 quantity will be excluded)
   quantity_adjustments: z.array(z.object({
     request_id: z.number().min(1, "Request ID is required"),
     quantity: z.number().min(0, "Quantity must be 0 or greater"),
   })).optional(),
+  // New field for additional items
+  additional_items: z.array(z.object({
+    product_variant_id: z.number().min(1, "Product variant ID is required"),
+    quantity: z.number().min(1, "Quantity must be at least 1"),
+  })).optional(),
+}).refine((data) => {
+  // Either request_ids or additional_items (or both) must be provided
+  return (data.request_ids && data.request_ids.length > 0) || 
+         (data.additional_items && data.additional_items.length > 0);
+}, {
+  message: "Either request_ids or additional_items (or both) must be provided",
+  path: ["request_ids"], // This will show the error on request_ids field
 });
 
 export const missingVariantFiltersSchema = z.object({

--- a/src/services/missing-variants-service.ts
+++ b/src/services/missing-variants-service.ts
@@ -148,11 +148,18 @@ export const createExitBillFromMissingVariants = async (
   const requestBody = {
     franchise_id: data.franchise_id,
     company_id: data.company_id,
-    request_ids: data.request_ids,
     comment: data.comment,
+    // Include request_ids only if provided and not empty
+    ...(data.request_ids && data.request_ids.length > 0 && { 
+      request_ids: data.request_ids 
+    }),
     // Include quantity adjustments only if there are items with quantity > 0
     ...(filteredQuantityAdjustments && filteredQuantityAdjustments.length > 0 && { 
       quantity_adjustments: filteredQuantityAdjustments 
+    }),
+    // Include additional_items if provided
+    ...(data.additional_items && data.additional_items.length > 0 && { 
+      additional_items: data.additional_items 
     }),
   };
 


### PR DESCRIPTION
- Added functionality to create exit bills with additional items alongside missing variant requests.
- Introduced a new button in the app bar for creating exit bills specifically for additional items.
- Updated the CreateExitBillDialog to handle additional items, including a new field for item quantities.
- Enhanced the form validation to ensure either request_ids or additional_items must be provided.
- Improved UI components for better organization and user experience when managing exit bills.