### PR TITLE
feat(variant-deposits): implement variant deposits feature for franchise management

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -90,6 +90,7 @@ import FranchiseExpensesReportsPage from "@/pages/franchise/dashboard/franchise-
 import FranchiseInventoryPage from "@/pages/franchise/dashboard/franchise-inventory-page";
 import FranchiseMenuPage from "@/pages/franchise/dashboard/franchise-menu-page";
 import FranchiseMissingVariantsPage from "@/pages/franchise/dashboard/franchise-missing-variants-page";
+import FranchiseVariantDepositsPage from "@/pages/franchise/dashboard/franchise-variant-deposits-page";
 import FranchiseProductsPage from "@/pages/franchise/dashboard/franchise-products-page";
 import FranchiseSalesPage from "@/pages/franchise/dashboard/franchise-sales-page";
 import FranchiseStockAlertsConfigPage from "@/pages/franchise/dashboard/franchise-stock-alerts-config-page";
@@ -134,6 +135,7 @@ export default function AppRouter() {
             <Route path="inventory" element={<FranchiseInventoryPage />} />
             <Route path="products" element={<FranchiseProductsPage />} />
             <Route path="missing-variants" element={<FranchiseMissingVariantsPage />} />
+            <Route path="variant-deposits" element={<FranchiseVariantDepositsPage />} />
             <Route path="statistics" element={<CompanyFranchiseStatsPage />} />
             <Route path="crm">
               <Route path="customers" element={<FranchiseCustomersPage />} />

--- a/src/components/feature-specific/company-franchises/franchise-card.tsx
+++ b/src/components/feature-specific/company-franchises/franchise-card.tsx
@@ -14,7 +14,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Franchise } from "@/models/data/franchise.model";
 import { deleteFranchise, getFranchiseAdministratorToken } from "@/services/franchise-service";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CircleUserRound, Copy, Inspect, Key, MapPin, Trash2 } from "lucide-react";
+import { CircleUserRound, Copy, ExternalLink, Inspect, Key, MapPin, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import FranchiseInsights from "./franchise-insights";
@@ -32,6 +32,8 @@ export default function ({ franchise, dateRange }: Props) {
   const [open, setOpen] = useState(false);
   const [tokenDialogOpen, setTokenDialogOpen] = useState(false);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [dashboardDialogOpen, setDashboardDialogOpen] = useState(false);
+  const [dashboardLink, setDashboardLink] = useState<string | null>(null);
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -79,6 +81,37 @@ export default function ({ franchise, dateRange }: Props) {
       });
     },
   });
+
+  const { mutate: openDashboardMutation, isPending: isOpenDashboardLoading } = useMutation({
+    mutationFn: getFranchiseAdministratorToken,
+    onSuccess: (data) => {
+      const url = `${window.location.origin}/myFranchise/login?token=${encodeURIComponent(data.data.token)}`;
+      setDashboardLink(url);
+      setDashboardDialogOpen(true);
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleCopyDashboardLink = () => {
+    if (dashboardLink) {
+      navigator.clipboard.writeText(dashboardLink);
+      toast({
+        title: "Copied",
+        description: "Link copied to clipboard",
+      });
+    }
+  };
+
+  const handleDashboardDialogOpenChange = (newOpen: boolean) => {
+    setDashboardDialogOpen(newOpen);
+    if (!newOpen) setDashboardLink(null);
+  };
 
   const handleCopyToken = () => {
     if (generatedToken) {
@@ -233,6 +266,68 @@ export default function ({ franchise, dateRange }: Props) {
           </Dialog>
         )}
         <MakeBillDialog franchise={franchise} />
+        {isAdmin && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-shrink-0"
+              disabled={isOpenDashboardLoading}
+              onClick={() => openDashboardMutation(franchise.ID)}
+              title="Get link to open franchise dashboard in an incognito window"
+            >
+              <ExternalLink className="h-4 w-4 sm:mr-2" />
+              <span className="hidden sm:inline">{isOpenDashboardLoading ? "Loading…" : "Open dashboard"}</span>
+            </Button>
+            <Dialog open={dashboardDialogOpen} onOpenChange={handleDashboardDialogOpenChange}>
+              <DialogContent className="sm:max-w-[500px] max-w-[95vw]">
+                <DialogHeader>
+                  <DialogTitle className="text-base sm:text-lg">Open franchise dashboard</DialogTitle>
+                  <DialogDescription className="text-xs sm:text-sm">
+                    Open the link below in an <strong>incognito or private window</strong> to log in to the{" "}
+                    <span className="font-semibold">{franchise.name}</span> dashboard without affecting your current session.
+                  </DialogDescription>
+                </DialogHeader>
+                {dashboardLink && (
+                  <div className="space-y-3 py-2">
+                    <label className="text-xs sm:text-sm font-medium">Login link</label>
+                    <div className="flex gap-2">
+                      <Input
+                        value={dashboardLink}
+                        readOnly
+                        className="font-mono text-xs flex-1 min-w-0"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleCopyDashboardLink}
+                        className="flex-shrink-0"
+                        title="Copy link"
+                      >
+                        <Copy className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Copy the link and paste it into a new incognito/private window. The token in the link expires in 30 days.
+                    </p>
+                  </div>
+                )}
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => handleDashboardDialogOpenChange(false)}>
+                    Close
+                  </Button>
+                  {dashboardLink && (
+                    <Button onClick={handleCopyDashboardLink}>
+                      <Copy className="h-4 w-4 sm:mr-2" />
+                      Copy link
+                    </Button>
+                  )}
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </>
+        )}
         <Button 
           onClick={()=> navigate(franchise.ID.toString())}
           size="sm"

--- a/src/components/feature-specific/franchise-dashboard/franchise-menu.tsx
+++ b/src/components/feature-specific/franchise-dashboard/franchise-menu.tsx
@@ -1,6 +1,6 @@
 import { RootState } from "@/app/store";
 import WideButton from "@/components/common/wide-button";
-import { AlertTriangle, Apple, BarChart, Bell, DollarSign, ReceiptText, ShoppingCart, Users, Warehouse } from "lucide-react";
+import { AlertTriangle, Apple, BarChart, Bell, DollarSign, ReceiptText, ShoppingCart, Users, Wallet, Warehouse } from "lucide-react";
 import { useSelector } from "react-redux";
 import FranchiseTile from "./franchise-tile";
 
@@ -46,6 +46,11 @@ const quickMenu = [
     label: "Missing Variants",
     icon: AlertTriangle,
     href: "missing-variants",
+  },
+  {
+    label: "Variant Deposits",
+    icon: Wallet,
+    href: "variant-deposits",
   },
   {
     label: "Statistics",

--- a/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
+++ b/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
@@ -27,6 +27,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
+import { VariantDepositResponse } from "@/models/data/variant-deposit.model";
 import { SaleItemEntity } from "@/models/data/sale.model";
 import { CreateSaleSchema, createSaleSchema } from "@/schemas/sale";
 import {
@@ -34,6 +35,7 @@ import {
   downloadAndPrintFranchisePDF,
   getFranchiseInventory,
 } from "@/services/franchise-service";
+import { fulfillVariantDeposit } from "@/services/variant-deposits-service";
 import { getBOGOLineTotal } from "@/utils/pricing-utils";
 import { processSaleBarcode } from "@/utils/process-sale-barcodes";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -43,12 +45,33 @@ import { ChangeEvent, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
 
-export default function () {
+export interface AddFranchiseSaleDialogInitialDeposit {
+  deposit: VariantDepositResponse;
+  depositId: number;
+}
+
+export interface AddFranchiseSaleDialogProps {
+  /** When set, dialog is controlled and opened from outside (e.g. variant deposits "Create sale") */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** When set, prefill from this deposit and on submit call fulfill API instead of create sale */
+  initialFromDeposit?: AddFranchiseSaleDialogInitialDeposit | null;
+  /** Hide the trigger button (use when opening from variant deposits) */
+  hideTrigger?: boolean;
+}
+
+export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogProps) {
+  const { open: controlledOpen, onOpenChange, initialFromDeposit, hideTrigger } = props ?? {};
   const franchise = useSelector(
     (state: RootState) => state.franchise.franchise
   );
-  if (!franchise) return;
-  const [open, setOpen] = useState(false);
+  if (!franchise) return null;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+  const setOpen = (value: boolean) => {
+    if (onOpenChange) onOpenChange(value);
+    else setInternalOpen(value);
+  };
   const [input, setInput] = useState("");
   const [saleItems, setSaleItems] = useState<Array<SaleItemEntity>>([]);
   const { toast } = useToast();
@@ -68,8 +91,36 @@ export default function () {
     queryFn: () => getFranchiseInventory(franchise.ID),
   });
 
+  // Prefill from deposit when dialog opens with initialFromDeposit and inventory is loaded
+  useEffect(() => {
+    if (!initialFromDeposit || !open || !inventory?.data?.items) return;
+    const { deposit } = initialFromDeposit;
+    const invItem = inventory.data.items.find(
+      (i: { product_variant_id: number }) => i.product_variant_id === deposit.product_variant_id
+    );
+    if (!invItem?.product) return;
+    const product = invItem.product as { price?: number; franchise_price?: number; vip_franchise_price?: number | null };
+    const franchisePrice =
+      franchise.franchise_type === "vip" && product.vip_franchise_price != null
+        ? product.vip_franchise_price
+        : product.franchise_price ?? product.price ?? 0;
+    const item: SaleItemEntity = {
+      product_variant_id: deposit.product_variant_id,
+      variant_qr_code: (invItem as { product_variant?: { qr_code?: string } }).product_variant?.qr_code ?? "",
+      price: franchisePrice,
+      quantity: deposit.quantity,
+      discount: 0,
+    };
+    setSaleItems([item]);
+    form.setValue("phone_number", deposit.customer_phone);
+    form.setValue("discount", deposit.amount_paid);
+    form.setValue("sale_items", [
+      { product_variant_id: deposit.product_variant_id, price: franchisePrice, quantity: deposit.quantity, discount: 0 },
+    ]);
+  }, [initialFromDeposit, open, inventory?.data?.items, franchise.ID, franchise.franchise_type, form]);
+
   const barcodes: string[] =
-    inventory?.data?.items.map((item) => item.product_variant?.qr_code ?? "") ??
+    inventory?.data?.items.map((item: { product_variant?: { qr_code?: string } }) => item.product_variant?.qr_code ?? "") ??
     [];
   const myProcessBarcode = (barcodeValue?: string) =>
     processSaleBarcode({
@@ -193,7 +244,7 @@ export default function () {
   const { mutate: downloadAndPrintFranchisePDFMutation } = useMutation({
     mutationFn: downloadAndPrintFranchisePDF,
   });
-  const { mutate: createFranchiseSaleMutation, isPending } = useMutation({
+  const { mutate: createFranchiseSaleMutation, isPending: isCreatePending } = useMutation({
     mutationFn: createFranchiseSale,
     onSuccess: (data) => {
       setOpen(false);
@@ -219,7 +270,35 @@ export default function () {
       });
     },
   });
+  const { mutate: fulfillDepositMutation, isPending: isFulfillPending } = useMutation({
+    mutationFn: (depositId: number) => fulfillVariantDeposit(depositId),
+    onSuccess: (_, depositId) => {
+      setOpen(false);
+      onOpenChange?.(false);
+      toast({
+        title: "Sale created",
+        description: "Variant deposit fulfilled; sale created successfully.",
+      });
+      form.reset();
+      setSaleItems([]);
+      queryClient.invalidateQueries({ queryKey: ["franchise-variant-deposits"] });
+      queryClient.invalidateQueries({ queryKey: ["franchise-inventory", franchise.ID] });
+      queryClient.invalidateQueries({ queryKey: ["sales"] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Error",
+        description: error.message ?? "Failed to create sale from deposit",
+        variant: "destructive",
+      });
+    },
+  });
+  const isPending = isCreatePending || isFulfillPending;
   const handleCreateSale = (data: CreateSaleSchema) => {
+    if (initialFromDeposit) {
+      fulfillDepositMutation(initialFromDeposit.depositId);
+      return;
+    }
     // Validate all prices don't exceed product prices
     let hasInvalidPrice = false;
     data.sale_items.forEach((item, idx) => {
@@ -251,17 +330,19 @@ export default function () {
   };
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger>
-        <Button>
-          <Plus />
-          Sale
-        </Button>
-      </DialogTrigger>
+      {!hideTrigger && (
+        <DialogTrigger asChild>
+          <Button>
+            <Plus />
+            Sale
+          </Button>
+        </DialogTrigger>
+      )}
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="flex gap-2 items-center">
             <ShoppingCart />
-            Add Sale to {franchise.name}
+            {initialFromDeposit ? "Create sale from deposit" : `Add Sale to ${franchise.name}`}
           </DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-2">

--- a/src/components/feature-specific/franchise-variant-deposits/create-variant-deposit-dialog.tsx
+++ b/src/components/feature-specific/franchise-variant-deposits/create-variant-deposit-dialog.tsx
@@ -1,0 +1,212 @@
+import { RootState } from "@/app/store";
+import { ProductVariantCombobox } from "@/components/feature-specific/company-products/product-variant-combobox";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import {
+  CreateVariantDepositSchema,
+  createVariantDepositSchema,
+} from "@/schemas/variant-deposit";
+import { createVariantDeposit } from "@/services/variant-deposits-service";
+import { getFranchiseAllProducts } from "@/services/product-service";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { useSelector } from "react-redux";
+
+interface CreateVariantDepositDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function CreateVariantDepositDialog({
+  open,
+  onOpenChange,
+}: CreateVariantDepositDialogProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const franchise = useSelector((state: RootState) => state.franchise.franchise);
+
+  const form = useForm<CreateVariantDepositSchema>({
+    resolver: zodResolver(createVariantDepositSchema),
+    defaultValues: {
+      customer_phone: "",
+      product_variant_id: 0,
+      amount_paid: 0,
+      quantity: 1,
+      comment: "",
+    },
+  });
+
+  const { data: productsData } = useQuery({
+    queryKey: ["franchise-products", franchise?.company_id],
+    queryFn: () => getFranchiseAllProducts(franchise?.company_id ?? 0),
+    enabled: !!franchise?.company_id && open,
+  });
+
+  const allVariants =
+    productsData?.data?.flatMap((p) => p.product_variants || []).filter(Boolean) ?? [];
+
+  const { mutate: createMutation, isPending } = useMutation({
+    mutationFn: createVariantDeposit,
+    onSuccess: () => {
+      toast({
+        title: "Success",
+        description: "Variant deposit recorded successfully",
+      });
+      queryClient.invalidateQueries({ queryKey: ["franchise-variant-deposits"] });
+      form.reset();
+      onOpenChange(false);
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to record deposit",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: CreateVariantDepositSchema) => {
+    createMutation(data);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Record variant deposit</DialogTitle>
+          <DialogDescription>
+            Record money received from a customer for a product variant. When the variant is in stock, you can create a sale from this deposit.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="customer_phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Customer phone</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g. 0550123456"
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="product_variant_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Product variant</FormLabel>
+                  <FormControl>
+                    <ProductVariantCombobox
+                      variants={allVariants}
+                      value={field.value || undefined}
+                      onChange={(v) => field.onChange(v ?? 0)}
+                      placeholder="Select a product variant"
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="amount_paid"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Amount paid</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={0}
+                      {...field}
+                      onChange={(e) => field.onChange(Number(e.target.value) || 0)}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="quantity"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Quantity</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      {...field}
+                      onChange={(e) => field.onChange(Number(e.target.value) || 1)}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="comment"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Comment (optional)</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="Notes..." {...field} disabled={isPending} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Saving..." : "Record deposit"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-app-bar.tsx
+++ b/src/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-app-bar.tsx
@@ -1,0 +1,20 @@
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+
+interface FranchiseVariantDepositsAppBarProps {
+  onRecordDeposit: () => void;
+}
+
+export default function FranchiseVariantDepositsAppBar({
+  onRecordDeposit,
+}: FranchiseVariantDepositsAppBarProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="text-lg font-semibold">Variant deposits (advance orders)</h2>
+      <Button onClick={onRecordDeposit}>
+        <Plus className="h-4 w-4 mr-2" />
+        Record deposit
+      </Button>
+    </div>
+  );
+}

--- a/src/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-body.tsx
+++ b/src/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-body.tsx
@@ -1,0 +1,158 @@
+import { RootState } from "@/app/store";
+import AddFranchiseSaleDialog from "@/components/feature-specific/franchise-sales/add-franchise-sale-dialog";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DataTable } from "@/components/ui/data-table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { VariantDepositResponse } from "@/models/data/variant-deposit.model";
+import { PaginationMeta } from "@/models/responses/company-stats.model";
+import {
+  getVariantDeposits,
+  updateVariantDeposit,
+} from "@/services/variant-deposits-service";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useSelector } from "react-redux";
+import { createFranchiseVariantDepositsColumns } from "./franchise-variant-deposits-columns";
+
+export default function FranchiseVariantDepositsBody() {
+  const franchise = useSelector((state: RootState) => state.franchise.franchise);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [page, setPage] = useState(1);
+  const limit = 20;
+
+  if (!franchise) return null;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["franchise-variant-deposits", franchise.ID, statusFilter, page, limit],
+    queryFn: () =>
+      getVariantDeposits({
+        status: statusFilter || undefined,
+        page,
+        limit,
+      }),
+    enabled: !!franchise,
+  });
+
+  const deposits: VariantDepositResponse[] = data?.data?.deposits ?? [];
+  const pagination = data?.data?.pagination;
+
+  const [depositForSaleDialog, setDepositForSaleDialog] = useState<VariantDepositResponse | null>(null);
+
+  const { mutate: cancelMutation, isPending: isCancelling } = useMutation({
+    mutationFn: ({ id }: { id: number }) =>
+      updateVariantDeposit(id, { status: "cancelled" }),
+    onSuccess: () => {
+      toast({ title: "Cancelled", description: "Deposit cancelled." });
+      queryClient.invalidateQueries({ queryKey: ["franchise-variant-deposits"] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to cancel deposit",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleOpenCreateSale = (deposit: VariantDepositResponse) => {
+    setDepositForSaleDialog(deposit);
+  };
+
+  const handleCancel = (deposit: VariantDepositResponse) => {
+    if (
+      window.confirm(
+        `Cancel this deposit for ${deposit.customer_phone}? This cannot be undone.`
+      )
+    ) {
+      cancelMutation({ id: deposit.id });
+    }
+  };
+
+  const columns = createFranchiseVariantDepositsColumns({
+    onFulfill: handleOpenCreateSale,
+    onCancel: handleCancel,
+  });
+
+  const pendingCount = deposits.filter((d) => d.status === "pending").length;
+  const fulfilledCount = deposits.filter((d) => d.status === "fulfilled").length;
+
+  if (isLoading) {
+    return <div className="p-4">Loading variant deposits...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <Select
+          value={statusFilter || "all"}
+          onValueChange={(v) => {
+            setStatusFilter(v === "all" ? "" : v);
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Filter by status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="fulfilled">Fulfilled</SelectItem>
+            <SelectItem value="cancelled">Cancelled</SelectItem>
+            <SelectItem value="refunded">Refunded</SelectItem>
+          </SelectContent>
+        </Select>
+        <span className="text-sm text-muted-foreground">
+          Pending: {pendingCount} · Fulfilled: {fulfilledCount}
+        </span>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Deposits</CardTitle>
+          <CardDescription>
+            When a variant is in stock, use &quot;Create sale&quot; to fulfill the deposit and create a sale (amount paid is applied as discount).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <DataTable
+            columns={columns}
+            data={deposits}
+            searchColumn="customer_phone"
+            paginationMeta={
+              pagination
+                ? ({
+                    total_items: pagination.total,
+                    total_pages: pagination.total_pages,
+                    current_page: pagination.page,
+                    per_page: pagination.limit,
+                  } as PaginationMeta)
+                : undefined
+            }
+            onPageChange={(p) => setPage(p + 1)}
+            currentPage={page - 1}
+          />
+        </CardContent>
+      </Card>
+
+      <AddFranchiseSaleDialog
+        open={!!depositForSaleDialog}
+        onOpenChange={(open) => !open && setDepositForSaleDialog(null)}
+        initialFromDeposit={
+          depositForSaleDialog
+            ? { deposit: depositForSaleDialog, depositId: depositForSaleDialog.id }
+            : null
+        }
+        hideTrigger
+      />
+    </div>
+  );
+}

--- a/src/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-columns.tsx
+++ b/src/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-columns.tsx
@@ -1,0 +1,131 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { VariantDepositResponse } from "@/models/data/variant-deposit.model";
+import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+import { ArrowUpDown, ShoppingCart, Trash2 } from "lucide-react";
+
+interface FranchiseVariantDepositsColumnsProps {
+  onFulfill?: (deposit: VariantDepositResponse) => void;
+  onCancel?: (deposit: VariantDepositResponse) => void;
+}
+
+export const createFranchiseVariantDepositsColumns = ({
+  onFulfill,
+  onCancel,
+}: FranchiseVariantDepositsColumnsProps = {}): ColumnDef<VariantDepositResponse>[] => [
+  {
+    accessorKey: "customer_phone",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Customer phone
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+  },
+  {
+    accessorKey: "product_name",
+    header: "Product",
+  },
+  {
+    accessorKey: "product_variant_color",
+    header: "Color",
+  },
+  {
+    accessorKey: "product_variant_size",
+    header: "Size",
+  },
+  {
+    accessorKey: "amount_paid",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Amount paid
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ getValue }) => {
+      const v = getValue() as number;
+      return v != null ? `${v.toLocaleString()}` : "—";
+    },
+  },
+  {
+    accessorKey: "quantity",
+    header: "Qty",
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ getValue }) => {
+      const status = getValue() as string;
+      const variant =
+        status === "pending"
+          ? "default"
+          : status === "fulfilled"
+            ? "secondary"
+            : "destructive";
+      return (
+        <Badge variant={variant}>
+          {status.charAt(0).toUpperCase() + status.slice(1)}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "created_at",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Created
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ getValue }) => {
+      const date = getValue() as string;
+      return date ? format(new Date(date), "MMM dd, yyyy") : "—";
+    },
+  },
+  {
+    id: "actions",
+    header: "Actions",
+    cell: ({ row }) => {
+      const deposit = row.original;
+      const isPending = deposit.status === "pending";
+      const canFulfill =
+        isPending && deposit.in_franchise_inventory === true && onFulfill;
+
+      return (
+        <div className="flex items-center gap-2">
+          {canFulfill && (
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => onFulfill(deposit)}
+              title="Create sale from this deposit"
+            >
+              <ShoppingCart className="h-4 w-4 mr-1" />
+              Create sale
+            </Button>
+          )}
+          {isPending && onCancel && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onCancel(deposit)}
+              title="Cancel deposit"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      );
+    },
+  },
+];

--- a/src/models/data/variant-deposit.model.ts
+++ b/src/models/data/variant-deposit.model.ts
@@ -1,0 +1,47 @@
+import { ProductVariant } from "./product.model";
+
+export type VariantDepositStatus = "pending" | "fulfilled" | "cancelled" | "refunded";
+
+export interface VariantDeposit {
+  id: number;
+  franchise_id: number;
+  customer_phone: string;
+  product_variant_id: number;
+  product_variant?: ProductVariant;
+  amount_paid: number;
+  quantity: number;
+  status: VariantDepositStatus;
+  sale_id?: number;
+  comment?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface VariantDepositResponse {
+  id: number;
+  franchise_id: number;
+  customer_phone: string;
+  product_variant_id: number;
+  product_name?: string;
+  product_variant_color?: string;
+  product_variant_size?: number;
+  amount_paid: number;
+  quantity: number;
+  status: VariantDepositStatus;
+  sale_id?: number;
+  comment?: string;
+  created_at: string;
+  updated_at: string;
+  in_franchise_inventory?: boolean;
+  franchise_inventory_qty?: number;
+}
+
+export interface VariantDepositListResponse {
+  deposits: VariantDepositResponse[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+  };
+}

--- a/src/pages/franchise/auth/franchise-login-page.tsx
+++ b/src/pages/franchise/auth/franchise-login-page.tsx
@@ -1,10 +1,51 @@
+import { useAppDispatch } from "@/app/hooks";
 import FranchiseAuthLoginForm from "@/components/feature-specific/franchise-auth/franchise-auth-login-form";
+import { login } from "@/features/auth/franchise-slice";
+import { useToast } from "@/hooks/use-toast";
+import { getMyAdminFranchise } from "@/services/franchise-service";
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
-export default function () {
+export default function FranchiseLoginPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const [loggingInWithToken, setLoggingInWithToken] = useState(false);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!token) return;
+    setLoggingInWithToken(true);
+    getMyAdminFranchise(token)
+      .then((res) => {
+        localStorage.setItem("token", token);
+        dispatch(login(res.data));
+        setSearchParams({}, { replace: true });
+        navigate("/myFranchise", { replace: true });
+      })
+      .catch((err) => {
+        toast({
+          title: "Login failed",
+          description: err.message ?? "Invalid or expired token",
+          variant: "destructive",
+        });
+        setSearchParams({}, { replace: true });
+        setLoggingInWithToken(false);
+      });
+  }, [token]);
+
+  if (loggingInWithToken) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <div className="text-muted-foreground">Logging you in…</div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-screen w-screen items-center justify-center">
       <FranchiseAuthLoginForm />
     </div>
-    
   );
 }

--- a/src/pages/franchise/dashboard/franchise-variant-deposits-page.tsx
+++ b/src/pages/franchise/dashboard/franchise-variant-deposits-page.tsx
@@ -1,0 +1,16 @@
+import CreateVariantDepositDialog from "@/components/feature-specific/franchise-variant-deposits/create-variant-deposit-dialog";
+import FranchiseVariantDepositsAppBar from "@/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-app-bar";
+import FranchiseVariantDepositsBody from "@/components/feature-specific/franchise-variant-deposits/franchise-variant-deposits-body";
+import { useState } from "react";
+
+export default function FranchiseVariantDepositsPage() {
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  return (
+    <div className="p-4 space-y-4">
+      <FranchiseVariantDepositsAppBar onRecordDeposit={() => setCreateDialogOpen(true)} />
+      <FranchiseVariantDepositsBody />
+      <CreateVariantDepositDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} />
+    </div>
+  );
+}

--- a/src/schemas/variant-deposit.ts
+++ b/src/schemas/variant-deposit.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const createVariantDepositSchema = z.object({
+  customer_phone: z.string().min(1, "Customer phone is required"),
+  product_variant_id: z.number().int().positive("Select a variant"),
+  amount_paid: z.number().int().min(0, "Amount must be 0 or more"),
+  quantity: z.number().int().min(1).default(1),
+  comment: z.string().optional(),
+});
+
+export type CreateVariantDepositSchema = z.infer<typeof createVariantDepositSchema>;
+
+export const updateVariantDepositSchema = z.object({
+  status: z.enum(["cancelled", "refunded"]).optional(),
+  comment: z.string().optional(),
+});
+
+export type UpdateVariantDepositSchema = z.infer<typeof updateVariantDepositSchema>;

--- a/src/services/variant-deposits-service.ts
+++ b/src/services/variant-deposits-service.ts
@@ -1,0 +1,97 @@
+import { baseUrl } from "@/app/constants";
+import {
+  VariantDeposit,
+  VariantDepositListResponse,
+  VariantDepositResponse,
+} from "@/models/data/variant-deposit.model";
+import { APIResponse } from "@/models/responses/api-response.model";
+import { CreateVariantDepositSchema } from "@/schemas/variant-deposit";
+
+const getAuthHeaders = () => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${localStorage.getItem("token")}`,
+});
+
+const handleApiError = async (response: Response) => {
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      (errorData as { message?: string })?.message || "API request failed"
+    );
+  }
+};
+
+/** Franchise admin: create a variant deposit (advance order) */
+export const createVariantDeposit = async (
+  data: CreateVariantDepositSchema
+): Promise<APIResponse<VariantDepositResponse>> => {
+  const response = await fetch(`${baseUrl}/franchise/variant-deposits`, {
+    method: "POST",
+    headers: getAuthHeaders(),
+    body: JSON.stringify(data),
+  });
+  await handleApiError(response);
+  return response.json();
+};
+
+/** Franchise admin: list variant deposits with optional filters */
+export const getVariantDeposits = async (params?: {
+  status?: string;
+  page?: number;
+  limit?: number;
+  product_variant_id?: number;
+}): Promise<APIResponse<VariantDepositListResponse>> => {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  if (params?.page) search.set("page", params.page.toString());
+  if (params?.limit) search.set("limit", params.limit.toString());
+  if (params?.product_variant_id)
+    search.set("product_variant_id", params.product_variant_id.toString());
+  const qs = search.toString();
+  const response = await fetch(
+    `${baseUrl}/franchise/variant-deposits${qs ? `?${qs}` : ""}`,
+    { method: "GET", headers: getAuthHeaders() }
+  );
+  await handleApiError(response);
+  return response.json();
+};
+
+/** Franchise admin: get one variant deposit */
+export const getVariantDeposit = async (
+  id: number
+): Promise<APIResponse<VariantDepositResponse>> => {
+  const response = await fetch(`${baseUrl}/franchise/variant-deposits/${id}`, {
+    method: "GET",
+    headers: getAuthHeaders(),
+  });
+  await handleApiError(response);
+  return response.json();
+};
+
+/** Franchise admin: update (e.g. cancel or refund) */
+export const updateVariantDeposit = async (
+  id: number,
+  data: { status?: "cancelled" | "refunded"; comment?: string }
+): Promise<APIResponse<VariantDepositResponse>> => {
+  const response = await fetch(`${baseUrl}/franchise/variant-deposits/${id}`, {
+    method: "PUT",
+    headers: getAuthHeaders(),
+    body: JSON.stringify(data),
+  });
+  await handleApiError(response);
+  return response.json();
+};
+
+/** Franchise admin: fulfill deposit by creating a sale */
+export const fulfillVariantDeposit = async (
+  id: number
+): Promise<
+  APIResponse<{ deposit: VariantDeposit; sale: { id: number; total: number } }>
+> => {
+  const response = await fetch(
+    `${baseUrl}/franchise/variant-deposits/${id}/fulfill`,
+    { method: "POST", headers: getAuthHeaders() }
+  );
+  await handleApiError(response);
+  return response.json();
+};


### PR DESCRIPTION

- Added functionality to create, view, and manage variant deposits (advance orders) within the franchise dashboard.
- Introduced new components for recording deposits, displaying deposits in a table, and fulfilling deposits by creating sales.
- Implemented API services for creating and retrieving variant deposits, including error handling and success notifications.
- Enhanced the franchise dashboard with a dedicated page for variant deposits, integrating filtering and pagination for better data management.
- Updated relevant models and schemas to support variant deposit operations.