### PR TITLE
feat(products): add pairable product feature and update forms

### DIFF
--- a/src/components/feature-specific/company-products/add-product-form.tsx
+++ b/src/components/feature-specific/company-products/add-product-form.tsx
@@ -294,6 +294,22 @@ export default function () {
               </FormItem>
             )}
           />
+          <FormField
+            name="pairable"
+            control={form.control}
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-center gap-2">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value ?? false}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <FormLabel>Pairable (pair promo when 2+ pairable units in cart)</FormLabel>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         </Form>
         <DialogFooter>
           <DialogClose asChild>

--- a/src/components/feature-specific/company-products/update-product-form.tsx
+++ b/src/components/feature-specific/company-products/update-product-form.tsx
@@ -43,6 +43,7 @@ export default function MyForm({ product }: Props) {
       description: product.description,
       is_woo_picture: product.is_woo_picture,
       is_bogo: product.is_bogo,
+      pairable: product.pairable ?? false,
       is_active: product.is_active,
     },
   });
@@ -269,6 +270,23 @@ export default function MyForm({ product }: Props) {
                   />
                 </FormControl>
                 <FormLabel>BOGO (buy one, get second at half price)</FormLabel>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="pairable"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-center gap-2">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value ?? false}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <FormLabel>Pairable (pair promo when 2+ pairable units in cart)</FormLabel>
                 <FormMessage />
               </FormItem>
             )}

--- a/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
+++ b/src/components/feature-specific/franchise-sales/add-franchise-sale-dialog.tsx
@@ -37,11 +37,11 @@ import {
   getFranchiseInventory,
 } from "@/services/franchise-service";
 import { fulfillVariantDeposit } from "@/services/variant-deposits-service";
-import { getBOGOLineTotal } from "@/utils/pricing-utils";
+import { computePairPromoLineTotals, getBOGOLineTotal } from "@/utils/pricing-utils";
 import { processSaleBarcode } from "@/utils/process-sale-barcodes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Info, Plus, ShoppingCart } from "lucide-react";
+import { Info, Plus, ShoppingCart, Trash2 } from "lucide-react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
@@ -238,6 +238,11 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
       Number.isNaN(parseInt(value)) ? 0 : parseInt(value)
     );
   }
+
+  function removeSaleItem(index: number) {
+    setSaleItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
   const queryClient = useQueryClient();
   const { mutate: downloadAndPrintFranchisePDFMutation } = useMutation({
     mutationFn: downloadAndPrintFranchisePDF,
@@ -390,6 +395,9 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                     <TableHead>Price</TableHead>
                     <TableHead>Quantity</TableHead>
                     <TableHead>Discount</TableHead>
+                    <TableHead className="w-[52px]">
+                      <span className="sr-only">Remove line</span>
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -401,6 +409,11 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                         productTotalQty[inv.product_id] = (productTotalQty[inv.product_id] ?? 0) + curr.quantity;
                       }
                     });
+                    const pairTotals = computePairPromoLineTotals(
+                      saleItems,
+                      inventory?.data?.items ?? [],
+                      franchise
+                    );
                     return saleItems.map((saleItem, idx) => {
                     const inventoryItem = inventory?.data?.items.find(
                       (s) =>
@@ -411,8 +424,11 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                     const productId = inventoryItem?.product_id;
                     const totalQtyForProduct = productId != null ? (productTotalQty[productId] ?? 0) : 0;
                     const hasPromo = product?.promo_price != null && product.promo_price > 0;
-                    const isBOGO = product?.is_bogo && totalQtyForProduct >= 2;
+                    const isPairLine = pairTotals.active && product?.pairable;
+                    const isBOGO = !isPairLine && product?.is_bogo && totalQtyForProduct >= 2;
                     const bogoProductTotal = isBOGO && product ? getBOGOLineTotal(product.price, totalQtyForProduct) : 0;
+                    const pairLineNet =
+                      isPairLine ? pairTotals.lineTotals[idx] ?? 0 : 0;
 
                     return (
                     <TableRow key={idx}>
@@ -425,6 +441,15 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                                 style: "currency",
                                 currency: "DZD",
                               }).format(product.promo_price ?? 0)}
+                            </Badge>
+                          )}
+                          {isPairLine && (
+                            <Badge variant="secondary" className="w-fit">
+                              Pair:{" "}
+                              {new Intl.NumberFormat("en-DZ", {
+                                style: "currency",
+                                currency: "DZD",
+                              }).format(pairLineNet)}
                             </Badge>
                           )}
                           {isBOGO && (
@@ -502,6 +527,17 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                           )}
                         />
                       </TableCell>
+                      <TableCell className="align-middle">
+                        <Button
+                          type="button"
+                          size="icon"
+                          className="h-8 w-8 shrink-0 bg-red-600 text-white hover:bg-red-700 hover:text-white"
+                          onClick={() => removeSaleItem(idx)}
+                          aria-label="Remove line"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
                     </TableRow>
                   );
                   });
@@ -559,18 +595,26 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                 {new Intl.NumberFormat("en-DZ", {
                   style: "currency",
                   currency: "DZD",
-                }).format(
+                }                ).format(
                   (() => {
                     const productTotalQty: Record<number, number> = {};
                     saleItems.forEach((c) => {
                       const inv = inventory?.data?.items.find((s) => s.product_variant_id === c.product_variant_id);
                       if (inv) productTotalQty[inv.product_id] = (productTotalQty[inv.product_id] ?? 0) + c.quantity;
                     });
-                    return saleItems.reduce((prev, curr) => {
+                    const pairTotals = computePairPromoLineTotals(
+                      saleItems,
+                      inventory?.data?.items ?? [],
+                      franchise
+                    );
+                    return saleItems.reduce((prev, curr, idx) => {
                       const invItem = inventory?.data?.items.find((s) => s.product_variant_id === curr.product_variant_id);
                       const prod = invItem?.product;
                       const pid = invItem?.product_id;
                       const totalQty = pid != null ? (productTotalQty[pid] ?? 0) : 0;
+                      if (pairTotals.active && prod?.pairable) {
+                        return prev + (pairTotals.lineTotals[idx] ?? 0);
+                      }
                       const lineTotal =
                         prod?.is_bogo && totalQty >= 2
                           ? Math.round((getBOGOLineTotal(prod.price, totalQty) / totalQty) * curr.quantity) - curr.discount * curr.quantity
@@ -622,18 +666,26 @@ export default function AddFranchiseSaleDialog(props?: AddFranchiseSaleDialogPro
                 {new Intl.NumberFormat("en-DZ", {
                   style: "currency",
                   currency: "DZD",
-                }).format(
+                }                ).format(
                   (() => {
                     const productTotalQty: Record<number, number> = {};
                     saleItems.forEach((c) => {
                       const inv = inventory?.data?.items.find((s) => s.product_variant_id === c.product_variant_id);
                       if (inv) productTotalQty[inv.product_id] = (productTotalQty[inv.product_id] ?? 0) + c.quantity;
                     });
-                    return saleItems.reduce((prev, curr) => {
+                    const pairTotals = computePairPromoLineTotals(
+                      saleItems,
+                      inventory?.data?.items ?? [],
+                      franchise
+                    );
+                    return saleItems.reduce((prev, curr, idx) => {
                       const invItem = inventory?.data?.items.find((s) => s.product_variant_id === curr.product_variant_id);
                       const prod = invItem?.product;
                       const pid = invItem?.product_id;
                       const totalQty = pid != null ? (productTotalQty[pid] ?? 0) : 0;
+                      if (pairTotals.active && prod?.pairable) {
+                        return prev + (pairTotals.lineTotals[idx] ?? 0);
+                      }
                       const lineTotal =
                         prod?.is_bogo && totalQty >= 2
                           ? Math.round((getBOGOLineTotal(prod.price, totalQty) / totalQty) * curr.quantity) - curr.discount * curr.quantity

--- a/src/models/data/product.model.ts
+++ b/src/models/data/product.model.ts
@@ -14,6 +14,8 @@ export interface Product {
     company_id: number;
     is_woo_picture: boolean;
     is_bogo: boolean;
+    /** When true, unit joins the pairable pool (min/max pairing when 2+ pairable units). */
+    pairable?: boolean;
     is_active: boolean;
     product_images: ProductImage[];
     product_variants: ProductVariant[];

--- a/src/schemas/product.ts
+++ b/src/schemas/product.ts
@@ -13,6 +13,7 @@ export const createProductSchema = z.object({
     sizes: z.array(z.number()).optional(),
     colors: z.array(z.string(), { message: "Color is required" }).optional(),
     is_bogo: z.boolean().optional(),
+    pairable: z.boolean().optional(),
     is_active: z.boolean().optional(),
 })
 
@@ -28,6 +29,7 @@ export const productDefaultValues = {
     colors: [],
     sizes: [],
     is_bogo: false,
+    pairable: false,
     is_active: true,
 }
 
@@ -72,6 +74,7 @@ export const updateProductSchema = z.object({
     description: z.string().optional(),
     is_woo_picture: z.boolean().optional(),
     is_bogo: z.boolean().optional(),
+    pairable: z.boolean().optional(),
     is_active: z.boolean().optional(),
 });
 

--- a/src/utils/pricing-utils.ts
+++ b/src/utils/pricing-utils.ts
@@ -53,3 +53,125 @@ export function getBOGOLineTotal(unitPrice: number, quantity: number): number {
   const halfPrice = Math.floor(unitPrice / 2);
   return unitPrice * fullUnits + halfPrice * halfUnits;
 }
+
+/** One physical unit in the pairable pool (mirrors backend PairableUnitInput). */
+export type PairableUnitInput = {
+  lineIndex: number;
+  unitIndex: number;
+  variantId: number;
+  productId: number;
+  firstPrice: number;
+  listPrice: number;
+  franchisePrice: number;
+  discountPerUnit: number;
+};
+
+function comparePairableMin(a: PairableUnitInput, b: PairableUnitInput): boolean {
+  if (a.firstPrice !== b.firstPrice) return a.firstPrice < b.firstPrice;
+  if (a.productId !== b.productId) return a.productId < b.productId;
+  if (a.variantId !== b.variantId) return a.variantId < b.variantId;
+  if (a.lineIndex !== b.lineIndex) return a.lineIndex < b.lineIndex;
+  return a.unitIndex < b.unitIndex;
+}
+
+function comparePairableMax(a: PairableUnitInput, b: PairableUnitInput): boolean {
+  if (a.firstPrice !== b.firstPrice) return a.firstPrice > b.firstPrice;
+  if (a.productId !== b.productId) return a.productId > b.productId;
+  if (a.variantId !== b.variantId) return a.variantId > b.variantId;
+  if (a.lineIndex !== b.lineIndex) return a.lineIndex > b.lineIndex;
+  return a.unitIndex > b.unitIndex;
+}
+
+/** Per-unit outcomes in the same order as `units`. */
+export function applyPairablePairing(units: PairableUnitInput[]): Array<{
+  lineIndex: number;
+  salePrice: number;
+  discountPerUnit: number;
+}> {
+  const n = units.length;
+  const pairs = Math.floor(n / 2);
+  const isHalf = new Array<boolean>(n).fill(false);
+  let remaining = units.map((_, i) => i);
+  for (let p = 0; p < pairs; p++) {
+    if (remaining.length < 2) break;
+    let minPos = 0;
+    for (let i = 1; i < remaining.length; i++) {
+      if (comparePairableMin(units[remaining[i]], units[remaining[minPos]])) minPos = i;
+    }
+    let maxPos = 0;
+    for (let i = 1; i < remaining.length; i++) {
+      if (comparePairableMax(units[remaining[i]], units[remaining[maxPos]])) maxPos = i;
+    }
+    const minIdx = remaining[minPos];
+    isHalf[minIdx] = true;
+    const nextRem: number[] = [];
+    for (let i = 0; i < remaining.length; i++) {
+      if (i !== minPos && i !== maxPos) nextRem.push(remaining[i]);
+    }
+    remaining = nextRem;
+  }
+  const out: Array<{ lineIndex: number; salePrice: number; discountPerUnit: number }> = [];
+  for (let i = 0; i < n; i++) {
+    const u = units[i];
+    const salePrice = isHalf[i] ? Math.floor(u.listPrice / 2) : u.listPrice;
+    out.push({ lineIndex: u.lineIndex, salePrice, discountPerUnit: u.discountPerUnit });
+  }
+  return out;
+}
+
+export type SaleLineForPair = {
+  product_variant_id: number;
+  quantity: number;
+  price: number;
+  discount: number;
+};
+
+export type InventoryRowForPair = {
+  product_variant_id: number;
+  product_id: number;
+  product?: Product;
+};
+
+/**
+ * When 2+ pairable units in the cart, returns per-line net totals (sale − per-unit discount × units counted).
+ * Otherwise `active` is false (use BOGO / list pricing).
+ */
+export function computePairPromoLineTotals(
+  saleItems: SaleLineForPair[],
+  inventoryItems: InventoryRowForPair[],
+  franchise: Franchise
+): { active: boolean; lineTotals: number[] } {
+  const lineTotals = saleItems.map(() => 0);
+  let pairableUnits = 0;
+  for (let i = 0; i < saleItems.length; i++) {
+    const inv = inventoryItems.find((x) => x.product_variant_id === saleItems[i].product_variant_id);
+    if (inv?.product?.pairable) pairableUnits += saleItems[i].quantity;
+  }
+  if (pairableUnits < 2) {
+    return { active: false, lineTotals };
+  }
+  const pool: PairableUnitInput[] = [];
+  for (let li = 0; li < saleItems.length; li++) {
+    const inv = inventoryItems.find((x) => x.product_variant_id === saleItems[li].product_variant_id);
+    const p = inv?.product;
+    if (!inv || !p?.pairable) continue;
+    const fp = getFranchisePrice(p, franchise);
+    for (let u = 0; u < saleItems[li].quantity; u++) {
+      pool.push({
+        lineIndex: li,
+        unitIndex: u,
+        variantId: saleItems[li].product_variant_id,
+        productId: inv.product_id,
+        firstPrice: p.first_price,
+        listPrice: p.price,
+        franchisePrice: fp,
+        discountPerUnit: saleItems[li].discount,
+      });
+    }
+  }
+  const outcomes = applyPairablePairing(pool);
+  for (const o of outcomes) {
+    lineTotals[o.lineIndex] += o.salePrice - o.discountPerUnit;
+  }
+  return { active: true, lineTotals };
+}


### PR DESCRIPTION
- Introduced a new 'pairable' field in product forms to allow pairing promotions for eligible products.
- Updated the add and update product forms to include the pairable checkbox.
- Enhanced pricing utilities to compute pair promo line totals when applicable.
- Modified the product model and schemas to support the new pairable attribute.
- Improved the add franchise sale dialog to handle pairable products in pricing calculations.