### PR TITLE
feat(woo-refund): implement web order refund functionality and enhance related components

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -55,6 +55,7 @@ import CompanySalesSwitchPage from "@/pages/dashboard/company/company-sales-swit
 import CompanyStatsPage from "@/pages/dashboard/company/company-stats-page";
 import CompanyBrokenItemsTransfersPage from "@/pages/dashboard/company/company-broken-items-transfers-page";
 import CompanyFranchiseFulfillmentPage from "@/pages/dashboard/company/company-franchise-fulfillment-page";
+import CompanyWooRefundPage from "@/pages/dashboard/company/company-woo-refund-page";
 import CompanyFranchiseShipFromStorePage from "@/pages/dashboard/company/company-franchise-ship-from-store-page";
 import CompanyFranchiseSupportRoutePage from "@/pages/dashboard/company/company-franchise-support-route-page";
 import CompanyFranchiseVariantDepositsPage from "@/pages/dashboard/company/company-franchise-variant-deposits-page";
@@ -97,6 +98,7 @@ import FranchiseMenuPage from "@/pages/franchise/dashboard/franchise-menu-page";
 import FranchiseMissingVariantsPage from "@/pages/franchise/dashboard/franchise-missing-variants-page";
 import FranchiseVariantDepositsPage from "@/pages/franchise/dashboard/franchise-variant-deposits-page";
 import FranchiseShipFromStorePage from "@/pages/franchise/dashboard/franchise-ship-from-store-page";
+import FranchiseWooRefundPage from "@/pages/franchise/dashboard/franchise-woo-refund-page";
 import FranchiseProductsPage from "@/pages/franchise/dashboard/franchise-products-page";
 import FranchiseSalesPage from "@/pages/franchise/dashboard/franchise-sales-page";
 import FranchiseStockAlertsConfigPage from "@/pages/franchise/dashboard/franchise-stock-alerts-config-page";
@@ -143,6 +145,7 @@ export default function AppRouter() {
             <Route path="missing-variants" element={<FranchiseMissingVariantsPage />} />
             <Route path="variant-deposits" element={<FranchiseVariantDepositsPage />} />
             <Route path="ship-from-store" element={<FranchiseShipFromStorePage />} />
+            <Route path="woo-refund" element={<FranchiseWooRefundPage />} />
             <Route
               path="ship-from-orders"
               element={<Navigate to="../ship-from-store?tab=orders" replace />}
@@ -231,6 +234,7 @@ export default function AppRouter() {
               path="franchise-fulfillment"
               element={<CompanyFranchiseFulfillmentPage />}
             />
+            <Route path="woo-refund" element={<CompanyWooRefundPage />} />
             <Route
               path="ship-from-store"
               element={<Navigate to="franchise-fulfillment?tab=shipments" replace />}
@@ -332,6 +336,7 @@ export default function AppRouter() {
                 path="franchise-fulfillment"
                 element={<CompanyFranchiseFulfillmentPage />}
               />
+              <Route path="woo-refund" element={<CompanyWooRefundPage />} />
               <Route
                 path="ship-from-store"
                 element={<Navigate to="franchise-fulfillment?tab=shipments" replace />}

--- a/src/components/feature-specific/company-products/product-variant-combobox.tsx
+++ b/src/components/feature-specific/company-products/product-variant-combobox.tsx
@@ -28,6 +28,8 @@ interface ProductVariantComboboxProps {
   disabled?: boolean;
   error?: string;
   extraText?: string;
+  /** Shown in the dropdown list next to each variant (e.g. unit price). */
+  variantSuffix?: (variantId: number) => string;
 }
 
 export function ProductVariantCombobox({
@@ -37,6 +39,7 @@ export function ProductVariantCombobox({
   placeholder = "Select variant...",
   disabled = false,
   extraText = "",
+  variantSuffix,
   error,
 }: ProductVariantComboboxProps) {
   const [open, setOpen] = React.useState(false);
@@ -85,7 +88,14 @@ export function ProductVariantCombobox({
                       value === variant.ID ? "opacity-100" : "opacity-0"
                     )}
                   />
-                  {variant.qr_code}
+                  <span className="flex flex-1 items-center justify-between gap-2">
+                    <span>{variant.qr_code}</span>
+                    {variantSuffix?.(variant.ID) ? (
+                      <span className="text-muted-foreground text-xs font-normal">
+                        {variantSuffix(variant.ID)}
+                      </span>
+                    ) : null}
+                  </span>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/src/components/feature-specific/franchise-dashboard/franchise-menu.tsx
+++ b/src/components/feature-specific/franchise-dashboard/franchise-menu.tsx
@@ -58,6 +58,11 @@ const quickMenu = [
     href: "ship-from-store",
   },
   {
+    label: "Web order refund",
+    icon: ReceiptText,
+    href: "woo-refund",
+  },
+  {
     label: "Statistics",
     icon: BarChart,
     href: "statistics",

--- a/src/components/feature-specific/woo-refund/company-franchise-woo-refund-detail-dialog.tsx
+++ b/src/components/feature-specific/woo-refund/company-franchise-woo-refund-detail-dialog.tsx
@@ -1,0 +1,210 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
+import { format } from "date-fns";
+import { CheckCircle2 } from "lucide-react";
+import {
+  formatRefundDZD,
+  formatRefundVariantLabel,
+} from "./woo-refund-display-utils";
+import { WooRefundLocalExchangeSummary } from "./woo-refund-local-exchange-summary";
+import {
+  canSettleRefund,
+  effectiveReimbursementStatus,
+  reimbursementAmountDue,
+} from "./woo-refund-reimbursement";
+
+type Props = {
+  refund: FranchiseWooRefund | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRecordPayment?: (refund: FranchiseWooRefund) => void;
+};
+
+export function CompanyFranchiseWooRefundDetailDialog({
+  refund,
+  open,
+  onOpenChange,
+  onRecordPayment,
+}: Props) {
+  if (!refund) return null;
+
+  const resolutionLabel =
+    refund.resolution_type === "local_exchange" ? "Local exchange" : "Cash refund";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            Refund #{refund.ID} — {refund.woo_order?.number ?? `order ${refund.woo_order_id}`}
+          </DialogTitle>
+        </DialogHeader>
+
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <dt className="text-muted-foreground">Date</dt>
+          <dd>
+            {refund.CreatedAt
+              ? format(new Date(refund.CreatedAt), "dd MMM yyyy HH:mm")
+              : "—"}
+          </dd>
+          <dt className="text-muted-foreground">Return store</dt>
+          <dd>{refund.franchise?.name ?? "—"}</dd>
+          <dt className="text-muted-foreground">Resolution</dt>
+          <dd>
+            <Badge variant="outline">{resolutionLabel}</Badge>
+          </dd>
+          <dt className="text-muted-foreground">Eligible amount</dt>
+          <dd>{formatRefundDZD(refund.eligible_amount)}</dd>
+          {refund.resolution_type === "cash_refund" ? (
+            <>
+              <dt className="text-muted-foreground">Cash paid to customer</dt>
+              <dd>{formatRefundDZD(refund.cash_paid_to_customer ?? 0)}</dd>
+            </>
+          ) : null}
+          {refund.reason ? (
+            <>
+              <dt className="text-muted-foreground">Reason</dt>
+              <dd className="col-span-1">{refund.reason}</dd>
+            </>
+          ) : null}
+          {reimbursementAmountDue(refund) > 0 ? (
+            <>
+              <dt className="text-muted-foreground">Owed to franchise</dt>
+              <dd>{formatRefundDZD(reimbursementAmountDue(refund))}</dd>
+              <dt className="text-muted-foreground">Company reimbursement</dt>
+              <dd>
+                {effectiveReimbursementStatus(refund) === "paid"
+                  ? "Paid to franchise"
+                  : effectiveReimbursementStatus(refund) === "pending"
+                    ? "Awaiting company payment"
+                    : "—"}
+              </dd>
+              {refund.reimbursed_at ? (
+                <>
+                  <dt className="text-muted-foreground">Paid on</dt>
+                  <dd>
+                    {format(new Date(refund.reimbursed_at), "dd MMM yyyy HH:mm")}
+                  </dd>
+                </>
+              ) : null}
+              {refund.reimbursement_reference ? (
+                <>
+                  <dt className="text-muted-foreground">Payment reference</dt>
+                  <dd>{refund.reimbursement_reference}</dd>
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </dl>
+
+        {refund.resolution_type === "local_exchange" ? (
+          <WooRefundLocalExchangeSummary refund={refund} />
+        ) : null}
+
+        {(refund.items?.length ?? 0) > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Returned items</p>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Product</TableHead>
+                  <TableHead className="text-right">Qty</TableHead>
+                  <TableHead className="text-right">Unit</TableHead>
+                  <TableHead className="text-right">Line total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {refund.items!.map((item) => (
+                  <TableRow key={item.ID}>
+                    <TableCell className="text-sm">
+                      {formatRefundVariantLabel(
+                        item.product_variant,
+                        item.product_variant_id
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">{item.quantity}</TableCell>
+                    <TableCell className="text-right">
+                      {formatRefundDZD(item.unit_price)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatRefundDZD(item.line_total)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {(refund.exchange_items?.length ?? 0) > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Exchange items</p>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Product</TableHead>
+                  <TableHead className="text-right">Qty</TableHead>
+                  <TableHead className="text-right">Unit</TableHead>
+                  <TableHead className="text-right">Discount</TableHead>
+                  <TableHead className="text-right">Line total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {refund.exchange_items!.map((item) => (
+                  <TableRow key={item.ID}>
+                    <TableCell className="text-sm">
+                      {formatRefundVariantLabel(
+                        item.product_variant,
+                        item.product_variant_id
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">{item.quantity}</TableCell>
+                    <TableCell className="text-right">
+                      {formatRefundDZD(item.unit_price)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatRefundDZD(item.discount ?? 0)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatRefundDZD(item.line_total)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {canSettleRefund(refund) && onRecordPayment ? (
+          <DialogFooter className="pt-2">
+            <Button
+              onClick={() => {
+                onRecordPayment(refund);
+                onOpenChange(false);
+              }}
+            >
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+              Record payment to franchise
+            </Button>
+          </DialogFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature-specific/woo-refund/company-franchise-woo-refunds-columns.tsx
+++ b/src/components/feature-specific/woo-refund/company-franchise-woo-refunds-columns.tsx
@@ -1,0 +1,139 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
+import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+import { Eye } from "lucide-react";
+import {
+  effectiveReimbursementStatus,
+  reimbursementAmountDue,
+} from "./woo-refund-reimbursement";
+import { WooRefundLocalExchangeSummary } from "./woo-refund-local-exchange-summary";
+
+const formatDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+const resolutionLabel = (type: string) =>
+  type === "local_exchange" ? "Local exchange" : "Cash refund";
+
+function reimbursementBadge(refund: FranchiseWooRefund) {
+  const status = effectiveReimbursementStatus(refund);
+  switch (status) {
+    case "pending":
+      return <Badge variant="outline">Awaiting payment</Badge>;
+    case "paid":
+      return (
+        <Badge variant="default" className="bg-emerald-600">
+          Paid to franchise
+        </Badge>
+      );
+    default:
+      return <Badge variant="secondary">N/A</Badge>;
+  }
+}
+
+export const companyFranchiseWooRefundsColumns: ColumnDef<FranchiseWooRefund>[] =
+  [
+    {
+      id: "date",
+      header: "Date",
+      accessorFn: (row) => row.CreatedAt,
+      cell: ({ row }) =>
+        row.original.CreatedAt
+          ? format(new Date(row.original.CreatedAt), "dd MMM yyyy HH:mm")
+          : "—",
+    },
+    {
+      id: "order",
+      header: "Order",
+      accessorFn: (row) => row.woo_order?.number ?? "",
+      cell: ({ row }) => (
+        <>
+          <span className="font-medium block">
+            {row.original.woo_order?.number ?? `#${row.original.woo_order_id}`}
+          </span>
+          {row.original.woo_order?.tracking_number ? (
+            <span className="text-xs text-muted-foreground block">
+              {row.original.woo_order.tracking_number}
+            </span>
+          ) : null}
+        </>
+      ),
+    },
+    {
+      id: "franchise",
+      header: "Return store",
+      accessorFn: (row) => row.franchise?.name ?? "",
+      cell: ({ row }) => row.original.franchise?.name ?? "—",
+    },
+    {
+      id: "resolution",
+      header: "Resolution",
+      accessorKey: "resolution_type",
+      cell: ({ row }) => (
+        <Badge
+          variant={
+            row.original.resolution_type === "cash_refund"
+              ? "default"
+              : "secondary"
+          }
+        >
+          {resolutionLabel(row.original.resolution_type)}
+        </Badge>
+      ),
+    },
+    {
+      id: "reimbursement",
+      header: "Payment status",
+      cell: ({ row }) => reimbursementBadge(row.original),
+    },
+    {
+      id: "exchange_details",
+      header: "Local exchange",
+      cell: ({ row }) => {
+        const r = row.original;
+        if (r.resolution_type !== "local_exchange") {
+          return <span className="text-xs text-muted-foreground">—</span>;
+        }
+        return <WooRefundLocalExchangeSummary refund={r} compact />;
+      },
+    },
+    {
+      id: "amount",
+      header: "Owed to franchise",
+      cell: ({ row }) => {
+        const due = reimbursementAmountDue(row.original);
+        if (due <= 0) {
+          return <span className="text-xs text-muted-foreground">—</span>;
+        }
+        return formatDZD(due);
+      },
+    },
+  ];
+
+/** Columns with view action — pass onView from parent. */
+export function createCompanyFranchiseWooRefundsColumns(
+  onView: (refund: FranchiseWooRefund) => void
+): ColumnDef<FranchiseWooRefund>[] {
+  return [
+    ...companyFranchiseWooRefundsColumns.filter((c) => c.id !== "actions"),
+    {
+      id: "actions",
+      header: "",
+      cell: ({ row }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onView(row.original)}
+          aria-label="View refund details"
+        >
+          <Eye className="h-4 w-4" />
+        </Button>
+      ),
+    },
+  ];
+}

--- a/src/components/feature-specific/woo-refund/company-franchise-woo-refunds-table.tsx
+++ b/src/components/feature-specific/woo-refund/company-franchise-woo-refunds-table.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/ui/data-table";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
+import { CheckCircle2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { createCompanyFranchiseWooRefundsColumns } from "./company-franchise-woo-refunds-columns";
+import {
+  canSettleRefund,
+  reimbursementAmountDue,
+} from "./woo-refund-reimbursement";
+
+const formatDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+type Props = {
+  refunds: FranchiseWooRefund[];
+  onView: (refund: FranchiseWooRefund) => void;
+  onRequestSettle: (refunds: FranchiseWooRefund[]) => void;
+  isSettling?: boolean;
+};
+
+export function CompanyFranchiseWooRefundsTable({
+  refunds,
+  onView,
+  onRequestSettle,
+  isSettling,
+}: Props) {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const settleableRefunds = useMemo(
+    () => refunds.filter(canSettleRefund),
+    [refunds]
+  );
+
+  const selectedRefunds = useMemo(
+    () =>
+      refunds.filter(
+        (r) => selectedIds.includes(String(r.ID)) && canSettleRefund(r)
+      ),
+    [refunds, selectedIds]
+  );
+
+  const selectedTotal = useMemo(
+    () =>
+      selectedRefunds.reduce((sum, r) => sum + reimbursementAmountDue(r), 0),
+    [selectedRefunds]
+  );
+
+  const columns = useMemo(
+    () => createCompanyFranchiseWooRefundsColumns(onView),
+    [onView]
+  );
+
+  const selectAllSettleable = () => {
+    setSelectedIds(settleableRefunds.map((r) => String(r.ID)));
+  };
+
+  const clearSelection = () => setSelectedIds([]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2">
+        <span className="text-sm text-muted-foreground mr-1">
+          {settleableRefunds.length} awaiting payment
+          {selectedRefunds.length > 0 && (
+            <>
+              {" · "}
+              <span className="text-foreground font-medium">
+                {selectedRefunds.length} selected ({formatDZD(selectedTotal)})
+              </span>
+            </>
+          )}
+        </span>
+        <div className="flex flex-wrap gap-2 ml-auto">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={selectAllSettleable}
+            disabled={settleableRefunds.length === 0}
+          >
+            Select all
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={clearSelection}
+            disabled={selectedIds.length === 0}
+          >
+            Unselect all
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => onRequestSettle(selectedRefunds)}
+            disabled={selectedRefunds.length === 0 || isSettling}
+          >
+            <CheckCircle2 className="mr-2 h-4 w-4" />
+            Settle
+            {selectedRefunds.length > 0 ? ` (${selectedRefunds.length})` : ""}
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <DataTable
+          data={refunds}
+          searchColumn="order"
+          columns={columns}
+          selectedRows={selectedIds}
+          setSelectedRows={setSelectedIds}
+          getRowId={(row) => String(row.ID)}
+          isRowSelectable={canSettleRefund}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/feature-specific/woo-refund/franchise-woo-refunds-columns.tsx
+++ b/src/components/feature-specific/woo-refund/franchise-woo-refunds-columns.tsx
@@ -1,0 +1,117 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
+import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+import { Eye } from "lucide-react";
+import { effectiveReimbursementStatus } from "./woo-refund-reimbursement";
+
+const formatDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+const resolutionLabel = (type: string) =>
+  type === "local_exchange" ? "Local exchange" : "Cash refund";
+
+function companyPaymentBadge(refund: FranchiseWooRefund) {
+  const status = effectiveReimbursementStatus(refund);
+  switch (status) {
+    case "pending":
+      return <Badge variant="outline">Awaiting company payment</Badge>;
+    case "paid":
+      return (
+        <Badge variant="default" className="bg-emerald-600">
+          Paid by company
+        </Badge>
+      );
+    default:
+      return <Badge variant="secondary">N/A</Badge>;
+  }
+}
+
+export function createFranchiseWooRefundsColumns(
+  onView: (refund: FranchiseWooRefund) => void
+): ColumnDef<FranchiseWooRefund>[] {
+  return [
+    {
+      id: "date",
+      header: "Date",
+      accessorFn: (row) => row.CreatedAt,
+      cell: ({ row }) =>
+        row.original.CreatedAt
+          ? format(new Date(row.original.CreatedAt), "dd MMM yyyy HH:mm")
+          : "—",
+    },
+    {
+      id: "order",
+      header: "Order",
+      accessorFn: (row) => row.woo_order?.number ?? "",
+      cell: ({ row }) => (
+        <>
+          <span className="font-medium block">
+            {row.original.woo_order?.number ?? `#${row.original.woo_order_id}`}
+          </span>
+          {row.original.woo_order?.tracking_number ? (
+            <span className="text-xs text-muted-foreground block">
+              {row.original.woo_order.tracking_number}
+            </span>
+          ) : null}
+        </>
+      ),
+    },
+    {
+      id: "resolution",
+      header: "Resolution",
+      accessorKey: "resolution_type",
+      cell: ({ row }) => (
+        <Badge
+          variant={
+            row.original.resolution_type === "cash_refund"
+              ? "default"
+              : "secondary"
+          }
+        >
+          {resolutionLabel(row.original.resolution_type)}
+        </Badge>
+      ),
+    },
+    {
+      id: "reimbursement",
+      header: "Company payback",
+      cell: ({ row }) => companyPaymentBadge(row.original),
+    },
+    {
+      id: "amount",
+      header: "Cash / exchange",
+      cell: ({ row }) => {
+        const r = row.original;
+        if (r.resolution_type === "cash_refund") {
+          return formatDZD(r.cash_paid_to_customer ?? 0);
+        }
+        return (
+          <span className="text-xs">
+            Pays {formatDZD(r.exchange_customer_pays)} / receives{" "}
+            {formatDZD(r.exchange_customer_receives)}
+          </span>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "",
+      cell: ({ row }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onView(row.original)}
+          aria-label="View refund details"
+        >
+          <Eye className="h-4 w-4" />
+        </Button>
+      ),
+    },
+  ];
+}

--- a/src/components/feature-specific/woo-refund/mark-woo-refund-reimbursed-dialog.tsx
+++ b/src/components/feature-specific/woo-refund/mark-woo-refund-reimbursed-dialog.tsx
@@ -1,0 +1,138 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
+import { useEffect, useMemo, useState } from "react";
+
+const formatDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+type Props = {
+  refunds: FranchiseWooRefund[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (paymentReference: string) => void;
+  isPending?: boolean;
+};
+
+export function MarkWooRefundReimbursedDialog({
+  refunds,
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+}: Props) {
+  const [reference, setReference] = useState("");
+
+  useEffect(() => {
+    if (!open) setReference("");
+  }, [open]);
+
+  const total = useMemo(
+    () =>
+      refunds.reduce((sum, r) => sum + (r.cash_paid_to_customer ?? 0), 0),
+    [refunds]
+  );
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setReference("");
+    onOpenChange(next);
+  };
+
+  if (refunds.length === 0) return null;
+
+  const isBulk = refunds.length > 1;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {isBulk
+              ? `Settle ${refunds.length} reimbursements`
+              : "Record franchise reimbursement"}
+          </DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {isBulk ? (
+            <>
+              Confirm the company paid{" "}
+              <strong>{formatDZD(total)}</strong> total back to franchise stores
+              for <strong>{refunds.length}</strong> cash refunds.
+            </>
+          ) : (
+            <>
+              Confirm the company paid{" "}
+              <strong>{formatDZD(refunds[0].cash_paid_to_customer ?? 0)}</strong>{" "}
+              back to{" "}
+              <strong>{refunds[0].franchise?.name ?? "the franchise"}</strong> for
+              order{" "}
+              <strong>
+                {refunds[0].woo_order?.number ?? refunds[0].woo_order_id}
+              </strong>
+              .
+            </>
+          )}
+        </p>
+        {isBulk && (
+          <ul className="max-h-32 overflow-y-auto rounded-md border text-xs divide-y">
+            {refunds.map((r) => (
+              <li
+                key={r.ID}
+                className="flex justify-between gap-2 px-2 py-1.5"
+              >
+                <span className="truncate">
+                  {r.woo_order?.number ?? `#${r.woo_order_id}`} ·{" "}
+                  {r.franchise?.name ?? "Franchise"}
+                </span>
+                <span className="shrink-0 font-medium">
+                  {formatDZD(r.cash_paid_to_customer ?? 0)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="space-y-1">
+          <Label htmlFor="payment-ref">Payment reference (optional)</Label>
+          <Input
+            id="payment-ref"
+            placeholder="Transfer ID, cheque #, …"
+            value={reference}
+            onChange={(e) => setReference(e.target.value)}
+          />
+          {isBulk && (
+            <p className="text-xs text-muted-foreground">
+              Same reference will be saved on every selected refund.
+            </p>
+          )}
+        </div>
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={isPending}
+            onClick={() => onConfirm(reference.trim())}
+          >
+            {isPending
+              ? "Saving…"
+              : isBulk
+                ? `Settle ${refunds.length} refunds`
+                : "Mark as paid"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature-specific/woo-refund/woo-refund-display-utils.ts
+++ b/src/components/feature-specific/woo-refund/woo-refund-display-utils.ts
@@ -1,0 +1,84 @@
+import {
+  FranchiseWooRefund,
+  FranchiseWooRefundExchangeItem,
+  FranchiseWooRefundItem,
+} from "@/models/data/franchise-woo-refund.model";
+type RefundVariantLike = {
+  color?: string;
+  size?: number;
+  qr_code?: string;
+  product?: { name?: string };
+};
+
+export const formatRefundDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+export function formatRefundVariantLabel(
+  variant?: RefundVariantLike | null,
+  variantId?: number
+): string {
+  if (variant) {
+    const name = variant.product?.name;
+    const parts = [
+      name,
+      variant.color,
+      variant.size != null ? String(variant.size) : null,
+    ].filter(Boolean);
+    if (parts.length > 0) {
+      return parts.join(" · ");
+    }
+    if (variant.qr_code) {
+      return variant.qr_code;
+    }
+  }
+  return variantId ? `#${variantId}` : "—";
+}
+
+export function sumRefundItemLines(items: FranchiseWooRefundItem[] | undefined): number {
+  return (items ?? []).reduce((s, i) => s + (i.line_total ?? 0), 0);
+}
+
+export function sumExchangeItemLines(
+  items: FranchiseWooRefundExchangeItem[] | undefined
+): number {
+  return (items ?? []).reduce((s, i) => s + (i.line_total ?? 0), 0);
+}
+
+export function localExchangeCashDelta(refund: FranchiseWooRefund): {
+  pays: number;
+  receives: number;
+  netLabel: string;
+  netAmount: number;
+} {
+  const pays = refund.exchange_customer_pays ?? 0;
+  const receives = refund.exchange_customer_receives ?? 0;
+  const returned = sumRefundItemLines(refund.items);
+  const exchange = sumExchangeItemLines(refund.exchange_items);
+
+  if (pays > 0) {
+    return {
+      pays,
+      receives,
+      netLabel: "Customer pays franchise",
+      netAmount: pays,
+    };
+  }
+  if (receives > 0) {
+    return {
+      pays,
+      receives,
+      netLabel: "Customer receives from franchise",
+      netAmount: receives,
+    };
+  }
+  return {
+    pays,
+    receives,
+    netLabel: "No cash difference",
+    netAmount: 0,
+  };
+}

--- a/src/components/feature-specific/woo-refund/woo-refund-exchange-pricing.ts
+++ b/src/components/feature-specific/woo-refund/woo-refund-exchange-pricing.ts
@@ -1,0 +1,61 @@
+import { Product } from "@/models/data/product.model";
+import { FranchiseWooRefundExchangeItemInput } from "@/models/data/franchise-woo-refund.model";
+import { InventoryItemWithCost } from "@/models/responses/inventory-with-cost.model";
+
+/** Retail unit price for exchange lines (matches backend refund items). */
+export function getProductUnitPrice(product: Product | undefined): number {
+  return product?.price ?? 0;
+}
+
+export function unitPriceFromInventoryRow(row: InventoryItemWithCost): number {
+  return getProductUnitPrice(row.product);
+}
+
+export function buildVariantUnitPriceMap(
+  inventoryRows: InventoryItemWithCost[]
+): Map<number, number> {
+  const map = new Map<number, number>();
+  for (const row of inventoryRows) {
+    const variantId = row.product_variant_id ?? row.product_variant?.ID;
+    if (!variantId || map.has(variantId)) continue;
+    map.set(variantId, unitPriceFromInventoryRow(row));
+  }
+  return map;
+}
+
+export type ReturnedLinePricing = {
+  id: number;
+  label: string;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+};
+
+export function computeReturnedLinesTotal(
+  lines: ReturnedLinePricing[]
+): number {
+  return lines.reduce((sum, l) => sum + l.lineTotal, 0);
+}
+
+export function computeExchangeLinesTotal(
+  items: FranchiseWooRefundExchangeItemInput[],
+  variantUnitPrice: Map<number, number>
+): number {
+  return items.reduce((sum, ex) => {
+    if (!ex.product_variant_id || ex.quantity <= 0) return sum;
+    const unit = variantUnitPrice.get(ex.product_variant_id) ?? 0;
+    const discount = ex.discount ?? 0;
+    return sum + Math.max(0, unit - discount) * ex.quantity;
+  }, 0);
+}
+
+/** Positive delta → customer pays franchise; negative → customer receives. */
+export function computeExchangeCashDelta(
+  exchangeTotal: number,
+  returnedTotal: number
+): { customerPays: number; customerReceives: number } {
+  const delta = exchangeTotal - returnedTotal;
+  if (delta > 0) return { customerPays: delta, customerReceives: 0 };
+  if (delta < 0) return { customerPays: 0, customerReceives: -delta };
+  return { customerPays: 0, customerReceives: 0 };
+}

--- a/src/components/feature-specific/woo-refund/woo-refund-local-exchange-summary.tsx
+++ b/src/components/feature-specific/woo-refund/woo-refund-local-exchange-summary.tsx
@@ -1,0 +1,144 @@
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
+import { cn } from "@/lib/utils";
+import {
+  formatRefundDZD,
+  formatRefundVariantLabel,
+  localExchangeCashDelta,
+  sumExchangeItemLines,
+  sumRefundItemLines,
+} from "./woo-refund-display-utils";
+
+type Props = {
+  refund: FranchiseWooRefund;
+  /** Compact layout for table cells */
+  compact?: boolean;
+  className?: string;
+};
+
+function LineList({
+  title,
+  lines,
+  compact,
+}: {
+  title: string;
+  lines: { key: number; label: string; qty: number; unit: number; discount?: number; total: number }[];
+  compact?: boolean;
+}) {
+  if (lines.length === 0) {
+    return null;
+  }
+  return (
+    <div className={compact ? "space-y-0.5" : "space-y-1"}>
+      <p
+        className={cn(
+          "font-medium text-muted-foreground",
+          compact ? "text-[10px] uppercase tracking-wide" : "text-xs"
+        )}
+      >
+        {title}
+      </p>
+      <ul className={cn("space-y-0.5", compact ? "text-xs" : "text-sm")}>
+        {lines.map((line) => (
+          <li key={line.key} className="flex justify-between gap-2">
+            <span className="truncate min-w-0" title={line.label}>
+              {line.label}
+              <span className="text-muted-foreground"> ×{line.qty}</span>
+            </span>
+            <span className="shrink-0 tabular-nums">
+              {formatRefundDZD(line.total)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function WooRefundLocalExchangeSummary({
+  refund,
+  compact = false,
+  className,
+}: Props) {
+  if (refund.resolution_type !== "local_exchange") {
+    return null;
+  }
+
+  const returnedLines =
+    refund.items?.map((item) => ({
+      key: item.ID,
+      label: formatRefundVariantLabel(item.product_variant, item.product_variant_id),
+      qty: item.quantity,
+      unit: item.unit_price,
+      total: item.line_total,
+    })) ?? [];
+
+  const exchangeLines =
+    refund.exchange_items?.map((item) => ({
+      key: item.ID,
+      label: formatRefundVariantLabel(item.product_variant, item.product_variant_id),
+      qty: item.quantity,
+      unit: item.unit_price,
+      discount: item.discount,
+      total: item.line_total,
+    })) ?? [];
+
+  const returnedTotal = sumRefundItemLines(refund.items);
+  const exchangeTotal = sumExchangeItemLines(refund.exchange_items);
+  const cash = localExchangeCashDelta(refund);
+
+  return (
+    <div className={cn(compact ? "space-y-2 max-w-md" : "space-y-4", className)}>
+      <LineList title="Returned" lines={returnedLines} compact={compact} />
+      <LineList title="Exchange out" lines={exchangeLines} compact={compact} />
+
+      <div
+        className={cn(
+          "rounded-md border bg-muted/30 space-y-1",
+          compact ? "p-2 text-xs" : "p-3 text-sm"
+        )}
+      >
+        <div className="flex justify-between gap-2">
+          <span className="text-muted-foreground">Returned value</span>
+          <span className="tabular-nums font-medium">
+            {formatRefundDZD(returnedTotal)}
+          </span>
+        </div>
+        <div className="flex justify-between gap-2">
+          <span className="text-muted-foreground">Exchange value</span>
+          <span className="tabular-nums font-medium">
+            {formatRefundDZD(exchangeTotal)}
+          </span>
+        </div>
+        {(cash.pays > 0 || cash.receives > 0) && (
+          <>
+            {cash.pays > 0 && (
+              <div className="flex justify-between gap-2">
+                <span className="text-muted-foreground">Customer pays franchise</span>
+                <span className="tabular-nums">{formatRefundDZD(cash.pays)}</span>
+              </div>
+            )}
+            {cash.receives > 0 && (
+              <div className="flex justify-between gap-2">
+                <span className="text-muted-foreground">
+                  Customer receives from franchise
+                </span>
+                <span className="tabular-nums">{formatRefundDZD(cash.receives)}</span>
+              </div>
+            )}
+          </>
+        )}
+        <div
+          className={cn(
+            "flex justify-between gap-2 border-t pt-1 font-medium",
+            compact && "text-xs"
+          )}
+        >
+          <span>Value delta (exchange − returned)</span>
+          <span className="tabular-nums">
+            {formatRefundDZD(exchangeTotal - returnedTotal)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/feature-specific/woo-refund/woo-refund-page.tsx
+++ b/src/components/feature-specific/woo-refund/woo-refund-page.tsx
@@ -1,0 +1,766 @@
+import AppBarBackButton from "@/components/common/app-bar-back-button";
+import { ProductVariantCombobox } from "@/components/feature-specific/company-products/product-variant-combobox";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { Franchise } from "@/models/data/franchise.model";
+import { ProductVariant } from "@/models/data/product.model";
+import {
+  CreateFranchiseWooRefundRequest,
+  FranchiseWooRefundExchangeItemInput,
+  FranchiseWooRefundPreview,
+  WooOrderSearchHit,
+  WooRefundResolutionType,
+} from "@/models/data/franchise-woo-refund.model";
+import { getFranchiseInventory, getMyCompanyFranchises } from "@/services/franchise-service";
+import {
+  WooRefundApiScope,
+  createFranchiseWooRefund,
+  getWooRefundPreview,
+  searchWooOrdersForRefund,
+} from "@/services/woo-refund-service";
+import { InventoryItemWithCost } from "@/models/responses/inventory-with-cost.model";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Loader2, Plus, RotateCcw, Search, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  buildVariantUnitPriceMap,
+  computeExchangeCashDelta,
+  computeExchangeLinesTotal,
+  computeReturnedLinesTotal,
+  ReturnedLinePricing,
+} from "./woo-refund-exchange-pricing";
+
+const formatDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+export type WooRefundPageProps = {
+  scope: WooRefundApiScope;
+  companyId?: number;
+  defaultFranchiseId?: number;
+  backLabel?: string;
+  title?: string;
+};
+
+export default function WooRefundPage({
+  scope,
+  companyId,
+  defaultFranchiseId,
+  backLabel = "Back",
+  title = "Web order refund",
+}: WooRefundPageProps) {
+  const { toast } = useToast();
+  const [tracking, setTracking] = useState("");
+  const [phone, setPhone] = useState("");
+  const [searchEnabled, setSearchEnabled] = useState(false);
+  const [selectedOrder, setSelectedOrder] = useState<WooOrderSearchHit | null>(null);
+  const [preview, setPreview] = useState<FranchiseWooRefundPreview | null>(null);
+  const [returnFranchiseId, setReturnFranchiseId] = useState<number | undefined>(
+    defaultFranchiseId
+  );
+  const [resolution, setResolution] = useState<WooRefundResolutionType>("cash_refund");
+  const [cashPaid, setCashPaid] = useState("");
+  const [reason, setReason] = useState("");
+  const [exchangePays, setExchangePays] = useState("0");
+  const [exchangeReceives, setExchangeReceives] = useState("0");
+  const [exchangeItems, setExchangeItems] = useState<
+    FranchiseWooRefundExchangeItemInput[]
+  >([]);
+
+  const { data: franchisesData } = useQuery({
+    queryKey: ["company-franchises", companyId],
+    queryFn: () => getMyCompanyFranchises(companyId!),
+    enabled: scope === "company" && !!companyId,
+  });
+  const franchises: Franchise[] = franchisesData?.data ?? [];
+
+  const inventoryFranchiseId =
+    scope === "franchise" ? defaultFranchiseId : returnFranchiseId;
+
+  const { data: inventoryData } = useQuery({
+    queryKey: ["woo-refund-inventory", inventoryFranchiseId],
+    queryFn: () => getFranchiseInventory(inventoryFranchiseId!),
+    enabled: !!inventoryFranchiseId && !!preview?.can_refund,
+  });
+
+  const inventoryRows: InventoryItemWithCost[] =
+    inventoryData?.data?.items_with_cost ?? [];
+
+  const variantUnitPrice = useMemo(
+    () => buildVariantUnitPriceMap(inventoryRows),
+    [inventoryRows]
+  );
+
+  const exchangeVariants: ProductVariant[] = useMemo(() => {
+    const seen = new Set<number>();
+    const out: ProductVariant[] = [];
+    for (const it of inventoryRows) {
+      const v = it.product_variant;
+      if (v && v.ID > 0 && !seen.has(v.ID)) {
+        seen.add(v.ID);
+        out.push(v);
+      }
+    }
+    return out;
+  }, [inventoryRows]);
+
+  const returnedLinePricing: ReturnedLinePricing[] = useMemo(() => {
+    const items = selectedOrder?.confirmed_order_items ?? [];
+    return items.map((line) => {
+      const unitPrice = line.product?.price ?? 0;
+      const qty = line.quantity ?? 0;
+      const name = line.product?.name ?? "Product";
+      const variant = line.product_variant;
+      const label = variant
+        ? `${name} · ${variant.color} ${variant.size}`
+        : name;
+      return {
+        id: line.id,
+        label,
+        quantity: qty,
+        unitPrice,
+        lineTotal: unitPrice * qty,
+      };
+    });
+  }, [selectedOrder]);
+
+  const returnedLinesTotal = useMemo(
+    () => computeReturnedLinesTotal(returnedLinePricing),
+    [returnedLinePricing]
+  );
+
+  const exchangeLinesTotal = useMemo(
+    () => computeExchangeLinesTotal(exchangeItems, variantUnitPrice),
+    [exchangeItems, variantUnitPrice]
+  );
+
+  const exchangeCashDelta = useMemo(
+    () => computeExchangeCashDelta(exchangeLinesTotal, returnedLinesTotal),
+    [exchangeLinesTotal, returnedLinesTotal]
+  );
+
+  useEffect(() => {
+    if (resolution !== "local_exchange") return;
+    setExchangePays(String(exchangeCashDelta.customerPays));
+    setExchangeReceives(String(exchangeCashDelta.customerReceives));
+  }, [resolution, exchangeCashDelta]);
+
+  const searchQuery = useQuery({
+    queryKey: ["woo-refund-search", scope, tracking, phone, searchEnabled],
+    queryFn: () =>
+      searchWooOrdersForRefund(scope, {
+        tracking_number: tracking,
+        phone,
+      }),
+    enabled: searchEnabled && (!!tracking.trim() || !!phone.trim()),
+  });
+
+  const results = searchQuery.data?.data ?? [];
+
+  const resetFlow = () => {
+    setSelectedOrder(null);
+    setPreview(null);
+    setCashPaid("");
+    setReason("");
+    setExchangeItems([]);
+    setExchangePays("0");
+    setExchangeReceives("0");
+    setResolution("cash_refund");
+  };
+
+  const handleSearch = () => {
+    if (!tracking.trim() && !phone.trim()) {
+      toast({
+        title: "Enter a search term",
+        description: "Use tracking number and/or customer phone.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setSearchEnabled(true);
+    setSelectedOrder(null);
+    setPreview(null);
+  };
+
+  const selectOrder = async (order: WooOrderSearchHit) => {
+    setSelectedOrder(order);
+    setPreview(null);
+    try {
+      const res = await getWooRefundPreview(scope, order.id);
+      const p = res.data ?? null;
+      setPreview(p);
+      if (p?.can_refund && p.eligible_amount != null) {
+        setCashPaid(String(p.eligible_amount));
+      }
+      if (scope === "company" && order.franchise_id) {
+        setReturnFranchiseId(order.franchise_id);
+      }
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: e instanceof Error ? e.message : "Preview failed",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const submitMutation = useMutation({
+    mutationFn: (body: CreateFranchiseWooRefundRequest) =>
+      createFranchiseWooRefund(scope, body),
+    onSuccess: () => {
+      toast({ title: "Refund completed", description: "The return was recorded." });
+      resetFlow();
+      setSearchEnabled(false);
+      setTracking("");
+      setPhone("");
+    },
+    onError: (e: Error) => {
+      toast({
+        title: "Refund failed",
+        description: e.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const canSubmit = useMemo(() => {
+    if (!selectedOrder || !preview?.can_refund) return false;
+    const fid =
+      scope === "franchise" ? defaultFranchiseId : returnFranchiseId;
+    if (!fid) return false;
+    if (resolution === "cash_refund") {
+      const cash = parseInt(cashPaid, 10);
+      return !Number.isNaN(cash) && cash >= 0;
+    }
+    return (
+      exchangeItems.length > 0 &&
+      exchangeItems.every((x) => x.product_variant_id > 0 && x.quantity > 0)
+    );
+  }, [
+    selectedOrder,
+    preview,
+    scope,
+    defaultFranchiseId,
+    returnFranchiseId,
+    resolution,
+    cashPaid,
+    exchangeItems,
+  ]);
+
+  const handleSubmit = () => {
+    if (!selectedOrder || !preview?.can_refund) return;
+    const franchiseId =
+      scope === "franchise" ? defaultFranchiseId! : returnFranchiseId!;
+    const body: CreateFranchiseWooRefundRequest = {
+      woo_order_id: selectedOrder.id,
+      franchise_id: franchiseId,
+      resolution_type: resolution,
+      reason,
+    };
+    if (resolution === "cash_refund") {
+      body.cash_paid_to_customer = parseInt(cashPaid, 10) || 0;
+    } else {
+      body.exchange_items = exchangeItems;
+      body.exchange_customer_pays = parseInt(exchangePays, 10) || 0;
+      body.exchange_customer_receives = parseInt(exchangeReceives, 10) || 0;
+    }
+    submitMutation.mutate(body);
+  };
+
+  const orderStatusBadge = (status: string) => {
+    const s = status?.toLowerCase() ?? "";
+    if (s === "delivered") return <Badge variant="default">Delivered</Badge>;
+    if (s === "returned") return <Badge variant="secondary">Returned</Badge>;
+    return <Badge variant="outline">{status}</Badge>;
+  };
+
+  return (
+    <div className="p-4 space-y-4 max-w-4xl mx-auto">
+      <div className="flex items-center gap-2">
+        <AppBarBackButton destination={backLabel} />
+        <div>
+          <h1 className="text-lg font-semibold">{title}</h1>
+          <p className="text-xs text-muted-foreground">
+            Search delivered orders by tracking number or phone, then select one
+            to refund.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Find order</CardTitle>
+          <CardDescription>
+            Search delivered orders only by tracking number or phone, then pick a
+            match.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <Label htmlFor="tracking">Tracking number</Label>
+              <Input
+                id="tracking"
+                placeholder="Yalidine tracking…"
+                value={tracking}
+                onChange={(e) => setTracking(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="phone">Customer phone</Label>
+              <Input
+                id="phone"
+                placeholder="05…"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              />
+            </div>
+          </div>
+          <Button onClick={handleSearch} disabled={searchQuery.isFetching}>
+            {searchQuery.isFetching ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="mr-2 h-4 w-4" />
+            )}
+            Search
+          </Button>
+
+          {searchEnabled && !searchQuery.isFetching && results.length === 0 && (
+            <p className="text-sm text-muted-foreground">No orders found.</p>
+          )}
+
+          {results.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Order</TableHead>
+                  <TableHead>Tracking</TableHead>
+                  <TableHead>Phone</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {results.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className={
+                      selectedOrder?.id === row.id ? "bg-muted/50" : undefined
+                    }
+                  >
+                    <TableCell className="font-medium">{row.number}</TableCell>
+                    <TableCell className="text-xs">
+                      {row.tracking_number || "—"}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {row.customer_phone || row.customer_phone_2 || "—"}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {orderStatusBadge(row.order_status)}
+                        {row.has_refund && (
+                          <Badge variant="destructive">Refunded</Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size="sm"
+                        variant={
+                          selectedOrder?.id === row.id ? "default" : "outline"
+                        }
+                        disabled={row.has_refund}
+                        onClick={() => selectOrder(row)}
+                      >
+                        Select
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {selectedOrder && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Process refund</CardTitle>
+            <CardDescription>
+              Order {selectedOrder.number}
+              {selectedOrder.billing_name
+                ? ` · ${selectedOrder.billing_name}`
+                : ""}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!preview && (
+              <p className="text-sm text-muted-foreground">Loading preview…</p>
+            )}
+            {preview && !preview.can_refund && (
+              <p className="text-sm text-destructive">
+                {preview.block_reason || "This order cannot be refunded."}
+              </p>
+            )}
+            {preview?.can_refund && (
+              <>
+                <div className="rounded-md border p-3 text-sm space-y-1">
+                  <p>
+                    Eligible cash (product only):{" "}
+                    <strong>{formatDZD(preview.eligible_amount)}</strong>
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Final price {formatDZD(preview.final_price)} − delivery{" "}
+                    {formatDZD(preview.second_delivery_cost)}
+                  </p>
+                </div>
+
+                {scope === "company" && (
+                  <div className="space-y-1">
+                    <Label>Return location (franchise)</Label>
+                    <Select
+                      value={returnFranchiseId?.toString() ?? ""}
+                      onValueChange={(v) => setReturnFranchiseId(parseInt(v, 10))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select franchise where customer returned" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {franchises.map((f) => (
+                          <SelectItem key={f.ID} value={String(f.ID)}>
+                            {f.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <Label>Resolution</Label>
+                  <RadioGroup
+                    value={resolution}
+                    onValueChange={(v) =>
+                      setResolution(v as WooRefundResolutionType)
+                    }
+                    className="flex flex-col gap-2"
+                  >
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="cash_refund" id="cash_refund" />
+                      <Label htmlFor="cash_refund" className="font-normal">
+                        Cash refund
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem
+                        value="local_exchange"
+                        id="local_exchange"
+                      />
+                      <Label htmlFor="local_exchange" className="font-normal">
+                        Local exchange
+                      </Label>
+                    </div>
+                  </RadioGroup>
+                </div>
+
+                {resolution === "cash_refund" && (
+                  <div className="space-y-1">
+                    <Label htmlFor="cash">Cash paid to customer (DZD)</Label>
+                    <Input
+                      id="cash"
+                      type="number"
+                      min={0}
+                      max={preview.eligible_amount}
+                      value={cashPaid}
+                      onChange={(e) => setCashPaid(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                {resolution === "local_exchange" && (
+                  <div className="space-y-3">
+                    <p className="text-xs text-muted-foreground">
+                      Returned and exchange lines both use product retail price
+                      (product.price). Customer pays or receives the difference.
+                    </p>
+
+                    {returnedLinePricing.length > 0 && (
+                      <div className="rounded-md border overflow-hidden">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Returned (from order)</TableHead>
+                              <TableHead className="text-right w-16">Qty</TableHead>
+                              <TableHead className="text-right w-24">Unit</TableHead>
+                              <TableHead className="text-right w-28">Total</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {returnedLinePricing.map((line) => (
+                              <TableRow key={line.id}>
+                                <TableCell className="text-sm">{line.label}</TableCell>
+                                <TableCell className="text-right text-sm">
+                                  {line.quantity}
+                                </TableCell>
+                                <TableCell className="text-right text-sm">
+                                  {formatDZD(line.unitPrice)}
+                                </TableCell>
+                                <TableCell className="text-right text-sm font-medium">
+                                  {formatDZD(line.lineTotal)}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                            <TableRow className="bg-muted/40">
+                              <TableCell colSpan={3} className="text-sm font-medium">
+                                Returned value
+                              </TableCell>
+                              <TableCell className="text-right font-semibold">
+                                {formatDZD(returnedLinesTotal)}
+                              </TableCell>
+                            </TableRow>
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
+
+                    {exchangeItems.map((item, idx) => {
+                      const unit =
+                        item.product_variant_id > 0
+                          ? variantUnitPrice.get(item.product_variant_id) ?? 0
+                          : 0;
+                      const discount = item.discount ?? 0;
+                      const lineTotal =
+                        item.product_variant_id > 0
+                          ? Math.max(0, unit - discount) * item.quantity
+                          : 0;
+                      return (
+                      <div
+                        key={idx}
+                        className="flex flex-wrap items-end gap-2 border rounded p-2"
+                      >
+                        <div className="flex-1 min-w-[200px]">
+                          <ProductVariantCombobox
+                            variants={exchangeVariants}
+                            value={
+                              item.product_variant_id || undefined
+                            }
+                            onChange={(id) => {
+                              const next = [...exchangeItems];
+                              next[idx] = {
+                                ...next[idx],
+                                product_variant_id: id ?? 0,
+                              };
+                              setExchangeItems(next);
+                            }}
+                            extraText={unit > 0 ? formatDZD(unit) : ""}
+                            variantSuffix={(id) => {
+                              const p = variantUnitPrice.get(id) ?? 0;
+                              return p > 0 ? formatDZD(p) : "";
+                            }}
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label className="text-xs text-muted-foreground">
+                            Qty
+                          </Label>
+                          <Input
+                            type="number"
+                            min={1}
+                            className="w-20"
+                            value={item.quantity}
+                            onChange={(e) => {
+                              const next = [...exchangeItems];
+                              next[idx] = {
+                                ...next[idx],
+                                quantity:
+                                  parseInt(e.target.value, 10) || 1,
+                              };
+                              setExchangeItems(next);
+                            }}
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label className="text-xs text-muted-foreground">
+                            Discount
+                          </Label>
+                          <Input
+                            type="number"
+                            min={0}
+                            className="w-24"
+                            value={discount}
+                            onChange={(e) => {
+                              const next = [...exchangeItems];
+                              next[idx] = {
+                                ...next[idx],
+                                discount: parseFloat(e.target.value) || 0,
+                              };
+                              setExchangeItems(next);
+                            }}
+                          />
+                        </div>
+                        <div className="space-y-1 min-w-[100px]">
+                          <Label className="text-xs text-muted-foreground">
+                            Line total
+                          </Label>
+                          <p className="h-10 flex items-center text-sm font-medium tabular-nums">
+                            {item.product_variant_id > 0
+                              ? formatDZD(lineTotal)
+                              : "—"}
+                          </p>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="mb-0.5"
+                          onClick={() =>
+                            setExchangeItems(
+                              exchangeItems.filter((_, i) => i !== idx)
+                            )
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    );
+                    })}
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={!inventoryFranchiseId}
+                      onClick={() =>
+                        setExchangeItems([
+                          ...exchangeItems,
+                          { product_variant_id: 0, quantity: 1, discount: 0 },
+                        ])
+                      }
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add exchange line
+                    </Button>
+
+                    <div className="rounded-md border bg-muted/30 p-3 text-sm space-y-1">
+                      <div className="flex justify-between gap-4">
+                        <span className="text-muted-foreground">
+                          Exchange lines total
+                        </span>
+                        <span className="font-medium tabular-nums">
+                          {formatDZD(exchangeLinesTotal)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <span className="text-muted-foreground">
+                          Returned value
+                        </span>
+                        <span className="font-medium tabular-nums">
+                          {formatDZD(returnedLinesTotal)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between gap-4 border-t pt-2 font-semibold">
+                        <span>
+                          {exchangeCashDelta.customerPays > 0
+                            ? "Customer pays franchise"
+                            : exchangeCashDelta.customerReceives > 0
+                              ? "Customer receives from franchise"
+                              : "No cash difference"}
+                        </span>
+                        <span className="tabular-nums">
+                          {exchangeCashDelta.customerPays > 0
+                            ? formatDZD(exchangeCashDelta.customerPays)
+                            : exchangeCashDelta.customerReceives > 0
+                              ? formatDZD(exchangeCashDelta.customerReceives)
+                              : formatDZD(0)}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      <div className="space-y-1">
+                        <Label>Customer pays franchise</Label>
+                        <Input
+                          type="number"
+                          min={0}
+                          value={exchangePays}
+                          onChange={(e) => setExchangePays(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <Label>Customer receives from franchise</Label>
+                        <Input
+                          type="number"
+                          min={0}
+                          value={exchangeReceives}
+                          onChange={(e) => setExchangeReceives(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <div className="space-y-1">
+                  <Label htmlFor="reason">Reason (optional)</Label>
+                  <Textarea
+                    id="reason"
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    rows={2}
+                  />
+                </div>
+
+                <div className="flex gap-2">
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={!canSubmit || submitMutation.isPending}
+                  >
+                    {submitMutation.isPending && (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    )}
+                    Submit refund
+                  </Button>
+                  <Button type="button" variant="outline" onClick={resetFlow}>
+                    <RotateCcw className="mr-2 h-4 w-4" />
+                    Clear
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/feature-specific/woo-refund/woo-refund-reimbursement.ts
+++ b/src/components/feature-specific/woo-refund/woo-refund-reimbursement.ts
@@ -1,0 +1,74 @@
+import {
+  FranchiseWooRefund,
+  WooRefundReimbursementStatus,
+} from "@/models/data/franchise-woo-refund.model";
+
+/** Amount the company owes the franchise (cash refund or exchange cash to customer). */
+export function reimbursementAmountDue(refund: FranchiseWooRefund): number {
+  if (refund.resolution_type === "cash_refund") {
+    return refund.cash_paid_to_customer ?? 0;
+  }
+  if (refund.resolution_type === "local_exchange") {
+    const due =
+      (refund.exchange_customer_receives ?? 0) -
+      (refund.exchange_customer_pays ?? 0);
+    return due > 0 ? due : 0;
+  }
+  return 0;
+}
+
+/** Matches backend EffectiveReimbursementStatus (incl. legacy rows). */
+export function effectiveReimbursementStatus(
+  refund: FranchiseWooRefund
+): WooRefundReimbursementStatus {
+  if (
+    refund.reimbursement_status === "paid" ||
+    refund.reimbursed_at
+  ) {
+    return "paid";
+  }
+  if (reimbursementAmountDue(refund) <= 0) {
+    return "not_applicable";
+  }
+  if (refund.reimbursement_status === "pending") {
+    return "pending";
+  }
+  return "pending";
+}
+
+export function canSettleRefund(refund: FranchiseWooRefund): boolean {
+  return effectiveReimbursementStatus(refund) === "pending";
+}
+
+/**
+ * Customer cash paid to the franchise on a local exchange that is not already
+ * netted inside a pending reimbursement row (receives − pays on the same refund).
+ */
+export function exchangePaysReducingOutstanding(
+  refund: FranchiseWooRefund
+): number {
+  if (refund.resolution_type !== "local_exchange") {
+    return 0;
+  }
+  if (effectiveReimbursementStatus(refund) === "paid") {
+    return 0;
+  }
+  if (effectiveReimbursementStatus(refund) === "pending") {
+    return 0;
+  }
+  return refund.exchange_customer_pays ?? 0;
+}
+
+/** Net outstanding: pending company owes minus franchise collections from customers. */
+export function totalOutstandingReimbursement(
+  refunds: FranchiseWooRefund[]
+): number {
+  let total = 0;
+  for (const r of refunds) {
+    if (effectiveReimbursementStatus(r) === "pending") {
+      total += reimbursementAmountDue(r);
+    }
+    total -= exchangePaysReducingOutstanding(r);
+  }
+  return Math.max(0, total);
+}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -48,6 +48,7 @@ interface DataTableProps<TData, TValue> {
   selectedRows?: string[]; // List of selected row IDs
   setSelectedRows?: (ids: string[]) => void; // Setter for selected row IDs
   getRowId?: (row: TData) => string; // Function to get row ID
+  isRowSelectable?: (row: TData) => boolean;
   searchBar?: boolean;
 }
 
@@ -61,6 +62,7 @@ export function DataTable<TData, TValue>({
   selectedRows,
   setSelectedRows,
   getRowId,
+  isRowSelectable,
   searchBar = true,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
@@ -116,7 +118,9 @@ export function DataTable<TData, TValue>({
     pageCount,
     // Only enable row selection if all required props are present
     ...(selectionEnabled && {
-      enableRowSelection: true,
+      enableRowSelection: isRowSelectable
+        ? (row) => isRowSelectable(row.original)
+        : true,
       getRowId: getRowId,
       rowSelection,
       onRowSelectionChange: (updater: any) => {

--- a/src/models/data/franchise-woo-refund.model.ts
+++ b/src/models/data/franchise-woo-refund.model.ts
@@ -1,0 +1,130 @@
+export type WooRefundResolutionType = "cash_refund" | "local_exchange";
+
+export type WooRefundReimbursementStatus =
+  | "pending"
+  | "paid"
+  | "not_applicable";
+
+export interface FranchiseWooRefundPreview {
+  woo_order_id: number;
+  order_status: string;
+  eligible_amount: number;
+  final_price: number;
+  second_delivery_cost: number;
+  can_refund: boolean;
+  block_reason?: string;
+  existing_refund_id?: number;
+}
+
+export interface WooOrderSearchHit {
+  id: number;
+  number: string;
+  order_status: string;
+  tracking_number?: string;
+  customer_phone?: string;
+  customer_phone_2?: string;
+  billing_name?: string;
+  final_price?: number;
+  franchise_id?: number | null;
+  franchise?: { ID: number; name: string } | null;
+  confirmed_order_items?: Array<{
+    id: number;
+    quantity: number;
+    product?: { name: string; price: number };
+    product_variant?: { color: string; size: number };
+  }>;
+  has_refund: boolean;
+}
+
+export interface FranchiseWooRefundExchangeItemInput {
+  product_variant_id: number;
+  quantity: number;
+  discount?: number;
+}
+
+export interface CreateFranchiseWooRefundRequest {
+  woo_order_id: number;
+  franchise_id?: number;
+  resolution_type: WooRefundResolutionType;
+  reason?: string;
+  cash_paid_to_customer?: number;
+  exchange_items?: FranchiseWooRefundExchangeItemInput[];
+  exchange_customer_pays?: number;
+  exchange_customer_receives?: number;
+}
+
+export interface FranchiseWooRefundItem {
+  ID: number;
+  confirmed_order_item_id: number;
+  product_variant_id: number;
+  product_variant?: {
+    ID?: number;
+    color?: string;
+    size?: number;
+    qr_code?: string;
+    product?: { name?: string };
+  };
+  quantity: number;
+  unit_price: number;
+  line_total: number;
+}
+
+export interface FranchiseWooRefundExchangeItem {
+  ID: number;
+  product_variant_id: number;
+  product_variant?: {
+    ID?: number;
+    color?: string;
+    size?: number;
+    qr_code?: string;
+    product?: { name?: string };
+  };
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  line_total: number;
+}
+
+export interface FranchiseWooRefund {
+  ID: number;
+  CreatedAt: string;
+  UpdatedAt: string;
+  woo_order_id: number;
+  woo_order?: {
+    id?: number;
+    ID?: number;
+    number?: string;
+    tracking_number?: string;
+    customer_phone?: string;
+    order_status?: string;
+    final_price?: number;
+  };
+  franchise_id: number;
+  franchise?: { ID: number; name: string };
+  company_id: number;
+  resolution_type: WooRefundResolutionType;
+  status: string;
+  eligible_amount: number;
+  cash_paid_to_customer?: number | null;
+  exchange_customer_pays: number;
+  exchange_customer_receives: number;
+  reason?: string;
+  reimbursement_status?: WooRefundReimbursementStatus;
+  reimbursed_at?: string | null;
+  reimbursed_by_user_id?: number | null;
+  reimbursement_reference?: string;
+  items?: FranchiseWooRefundItem[];
+  exchange_items?: FranchiseWooRefundExchangeItem[];
+}
+
+export interface FranchiseLedgerEntry {
+  id: number;
+  created_at: string;
+  franchise_id: number;
+  company_id: number;
+  woo_order_id?: number;
+  franchise_woo_refund_id?: number;
+  entry_type: string;
+  amount: number;
+  comment?: string;
+}

--- a/src/pages/dashboard/company/company-control-panel-page.tsx
+++ b/src/pages/dashboard/company/company-control-panel-page.tsx
@@ -233,6 +233,11 @@ const quickMenu: Array<{
     href: "franchise-fulfillment",
   },
   {
+    label: "Web order refund",
+    icon: ReceiptText,
+    href: "woo-refund",
+  },
+  {
     label: "Send WhatsApp",
     icon: MessageSquare,
   },

--- a/src/pages/dashboard/company/company-franchise-fulfillment-page.tsx
+++ b/src/pages/dashboard/company/company-franchise-fulfillment-page.tsx
@@ -6,6 +6,14 @@ import { CompanyShipFromStoreEditDialog } from "@/components/feature-specific/sh
 import { createCompanyShipFromStoreColumns } from "@/components/feature-specific/ship-from-store/company-ship-from-store-columns";
 import { companyFranchiseCommissionsColumns } from "@/components/feature-specific/ship-from-store/company-franchise-commissions-columns";
 import { companyFranchiseFulfillmentOrdersColumns } from "@/components/feature-specific/ship-from-store/company-franchise-fulfillment-orders-columns";
+import { CompanyFranchiseWooRefundDetailDialog } from "@/components/feature-specific/woo-refund/company-franchise-woo-refund-detail-dialog";
+import { CompanyFranchiseWooRefundsTable } from "@/components/feature-specific/woo-refund/company-franchise-woo-refunds-table";
+import { MarkWooRefundReimbursedDialog } from "@/components/feature-specific/woo-refund/mark-woo-refund-reimbursed-dialog";
+import {
+  canSettleRefund,
+  effectiveReimbursementStatus,
+  totalOutstandingReimbursement,
+} from "@/components/feature-specific/woo-refund/woo-refund-reimbursement";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -37,6 +45,7 @@ import {
   FranchiseOrderStatus,
 } from "@/models/data/woo-order.model";
 import { ShipFromStore } from "@/models/data/ship-from-store.model";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
 import { WooOrder } from "@/models/data/woo-order.model";
 import { getMyCompanyFranchises } from "@/services/franchise-service";
 import {
@@ -46,10 +55,14 @@ import {
   listCompanyFranchiseFulfillmentShipments,
 } from "@/services/franchise-fulfillment-service";
 import {
+  listCompanyWooRefunds,
+  markCompanyWooRefundReimbursed,
+} from "@/services/woo-refund-service";
+import {
   deleteShipFromStoreAdmin,
 } from "@/services/ship-from-store-service";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { endOfDay, format, startOfDay } from "date-fns";
 import {
   CalendarIcon,
   CheckCircle2,
@@ -57,15 +70,17 @@ import {
   Package,
   Plus,
   Receipt,
+  RotateCcw,
   ShoppingBag,
   XCircle,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
 import { DateRange } from "react-day-picker";
 import { useSelector } from "react-redux";
 import { useLocation, useSearchParams } from "react-router-dom";
 
-const TAB_VALUES = ["shipments", "orders", "commissions"] as const;
+const TAB_VALUES = ["shipments", "orders", "commissions", "refunds"] as const;
 type TabValue = (typeof TAB_VALUES)[number];
 
 function isTabValue(value: string | null): value is TabValue {
@@ -115,6 +130,19 @@ export default function CompanyFranchiseFulfillmentPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editRecord, setEditRecord] = useState<ShipFromStore | null>(null);
   const [deleteRecord, setDeleteRecord] = useState<ShipFromStore | null>(null);
+  const [detailRefund, setDetailRefund] = useState<FranchiseWooRefund | null>(
+    null
+  );
+  const [settleRefunds, setSettleRefunds] = useState<FranchiseWooRefund[]>([]);
+  const [settleDialogOpen, setSettleDialogOpen] = useState(false);
+  const [reimbursementFilter, setReimbursementFilter] = useState<string>("all");
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    if (isTabValue(tab) && tab !== activeTab) {
+      setActiveTab(tab);
+    }
+  }, [searchParams, activeTab]);
 
   const handleTabChange = (value: string) => {
     if (!isTabValue(value)) return;
@@ -172,12 +200,118 @@ export default function CompanyFranchiseFulfillmentPage() {
     enabled: !!companyId,
   });
 
+  const refundsQuery = useQuery({
+    queryKey: [
+      "company-franchise-fulfillment-refunds",
+      companyId,
+      franchiseFilter,
+      reimbursementFilter,
+    ],
+    queryFn: () =>
+      listCompanyWooRefunds({
+        franchise_id: franchiseFilter,
+        reimbursement_status:
+          reimbursementFilter === "all" ? undefined : reimbursementFilter,
+        limit: 200,
+      }),
+    enabled: !!companyId,
+  });
+
+  const allRefundsForOutstandingQuery = useQuery({
+    queryKey: [
+      "company-franchise-fulfillment-refunds-outstanding",
+      companyId,
+      franchiseFilter,
+    ],
+    queryFn: () =>
+      listCompanyWooRefunds({
+        franchise_id: franchiseFilter,
+        limit: 500,
+      }),
+    enabled: !!companyId,
+  });
+
+  const markReimbursedMutation = useMutation({
+    mutationFn: async ({
+      refundIds,
+      paymentReference,
+    }: {
+      refundIds: number[];
+      paymentReference: string;
+    }) => {
+      const results = await Promise.allSettled(
+        refundIds.map((id) =>
+          markCompanyWooRefundReimbursed(id, {
+            payment_reference: paymentReference || undefined,
+          })
+        )
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0) {
+        throw new Error(
+          `${failed} of ${refundIds.length} refund(s) could not be settled.`
+        );
+      }
+      return results.length;
+    },
+    onSuccess: (count) => {
+      toast({
+        title: "Reimbursement recorded",
+        description:
+          count === 1
+            ? "The franchise has been marked as paid back."
+            : `${count} refunds marked as paid back.`,
+      });
+      setSettleDialogOpen(false);
+      setSettleRefunds([]);
+      queryClient.invalidateQueries({
+        queryKey: ["company-franchise-fulfillment-refunds"],
+      });
+    },
+    onError: (e: Error) => {
+      toast({
+        title: "Could not record payment",
+        description: e.message,
+        variant: "destructive",
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["company-franchise-fulfillment-refunds"],
+      });
+    },
+  });
+
   const shipments = shipmentsQuery.data?.data ?? [];
   const orders: WooOrder[] = ordersQuery.data?.data ?? [];
   const commissionsData: FranchiseCommissionsResponse | undefined =
     commissionsQuery.data?.data;
   const commissions = commissionsData?.commissions ?? [];
   const totals = commissionsData?.totals;
+
+  const refunds = useMemo(() => {
+    let rows = refundsQuery.data?.data ?? [];
+    if (dateRange?.from) {
+      const from = startOfDay(dateRange.from);
+      rows = rows.filter((r) => new Date(r.CreatedAt) >= from);
+    }
+    if (dateRange?.to) {
+      const to = endOfDay(dateRange.to);
+      rows = rows.filter((r) => new Date(r.CreatedAt) <= to);
+    }
+    return rows;
+  }, [refundsQuery.data, dateRange]);
+
+  const pendingReimbursementTotal = useMemo(
+    () =>
+      totalOutstandingReimbursement(
+        allRefundsForOutstandingQuery.data?.data ?? []
+      ),
+    [allRefundsForOutstandingQuery.data]
+  );
+
+  const pendingSettleCount = useMemo(
+    () => refunds.filter((r) => canSettleRefund(r)).length,
+    [refunds]
+  );
 
   const orderStats = useMemo(() => {
     const open = orders.filter((order) => {
@@ -234,12 +368,20 @@ export default function CompanyFranchiseFulfillmentPage() {
             </span>
           </div>
         </div>
-        {isAdmin && activeTab === "shipments" && (
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            New shipment
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" asChild>
+            <Link to={isModerator ? "../woo-refund" : "woo-refund"}>
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Web order refund
+            </Link>
           </Button>
-        )}
+          {isAdmin && activeTab === "shipments" && (
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              New shipment
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
@@ -326,6 +468,22 @@ export default function CompanyFranchiseFulfillmentPage() {
           </Select>
         )}
 
+        {activeTab === "refunds" && (
+          <Select
+            value={reimbursementFilter}
+            onValueChange={setReimbursementFilter}
+          >
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Reimbursement" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All reimbursements</SelectItem>
+              <SelectItem value="pending">Pending payback</SelectItem>
+              <SelectItem value="paid">Paid back</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+
         {activeTab === "commissions" && (
           <Select value={commissionStatus} onValueChange={setCommissionStatus}>
             <SelectTrigger className="w-[150px]">
@@ -391,6 +549,13 @@ export default function CompanyFranchiseFulfillmentPage() {
             Commissions
             <Badge variant="secondary" className="ml-2">
               {commissions.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="refunds">
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Refunds
+            <Badge variant="secondary" className="ml-2">
+              {refunds.length}
             </Badge>
           </TabsTrigger>
         </TabsList>
@@ -479,7 +644,94 @@ export default function CompanyFranchiseFulfillmentPage() {
             </CardContent>
           </Card>
         </TabsContent>
+
+        <TabsContent value="refunds" className="mt-4 space-y-3">
+          {pendingReimbursementTotal > 0 && reimbursementFilter !== "paid" && (
+            <Card>
+              <CardContent className="pt-4">
+                <p className="text-sm text-muted-foreground">
+                  Outstanding franchise reimbursements (cash refunds & exchange)
+                </p>
+                <p className="text-2xl font-semibold">
+                  {formatCurrency(pendingReimbursementTotal)}
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {pendingSettleCount} refund{pendingSettleCount === 1 ? "" : "s"} — select
+                  rows below, then click <strong>Settle</strong>.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+          <Card>
+            <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <CardTitle className="text-base">Web order refunds</CardTitle>
+                <p className="text-xs text-muted-foreground mt-1 max-w-xl">
+                  Local exchange rows show returned vs exchange lines and cash
+                  balance. Select pending reimbursements, then use{" "}
+                  <strong>Settle</strong> to record company payment to franchises.
+                </p>
+              </div>
+              <Button variant="outline" size="sm" asChild>
+                <Link to={isModerator ? "../woo-refund" : "woo-refund"}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  New refund
+                </Link>
+              </Button>
+            </CardHeader>
+            <CardContent>
+              {refundsQuery.isLoading ? (
+                <p className="text-sm text-muted-foreground">Loading...</p>
+              ) : refundsQuery.isError ? (
+                <p className="text-sm text-destructive">Failed to load refunds.</p>
+              ) : refunds.length === 0 ? (
+                <EmptyState
+                  icon={<RotateCcw className="h-6 w-6" />}
+                  title="No refunds"
+                  description="No web order refunds match your filters."
+                />
+              ) : (
+                <CompanyFranchiseWooRefundsTable
+                  refunds={refunds}
+                  onView={setDetailRefund}
+                  onRequestSettle={(rows) => {
+                    setSettleRefunds(rows);
+                    setSettleDialogOpen(true);
+                  }}
+                  isSettling={markReimbursedMutation.isPending}
+                />
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
       </Tabs>
+
+      <CompanyFranchiseWooRefundDetailDialog
+        refund={detailRefund}
+        open={!!detailRefund}
+        onOpenChange={(open) => !open && setDetailRefund(null)}
+        onRecordPayment={(r) => {
+          setSettleRefunds([r]);
+          setSettleDialogOpen(true);
+        }}
+      />
+
+      <MarkWooRefundReimbursedDialog
+        refunds={settleRefunds}
+        open={settleDialogOpen}
+        onOpenChange={(open) => {
+          setSettleDialogOpen(open);
+          if (!open) setSettleRefunds([]);
+        }}
+        isPending={markReimbursedMutation.isPending}
+        onConfirm={(paymentReference) => {
+          if (settleRefunds.length === 0) return;
+          markReimbursedMutation.mutate({
+            refundIds: settleRefunds.map((r) => r.ID),
+            paymentReference,
+          });
+        }}
+      />
 
       {isAdmin && (
         <>

--- a/src/pages/dashboard/company/company-woo-refund-page.tsx
+++ b/src/pages/dashboard/company/company-woo-refund-page.tsx
@@ -1,0 +1,25 @@
+import { RootState } from "@/app/store";
+import WooRefundPage from "@/components/feature-specific/woo-refund/woo-refund-page";
+import { useLocation } from "react-router-dom";
+import { useSelector } from "react-redux";
+
+export default function CompanyWooRefundPage() {
+  const { pathname } = useLocation();
+  const isModerator = pathname.includes("moderator");
+  const company = useSelector((state: RootState) =>
+    isModerator ? state.user.company : state.company.company
+  );
+
+  if (!company) {
+    return <div className="p-4">No company selected</div>;
+  }
+
+  return (
+    <WooRefundPage
+      scope="company"
+      companyId={company.ID}
+      backLabel={isModerator ? "Menu" : "Control panel"}
+      title="Web order refund"
+    />
+  );
+}

--- a/src/pages/franchise/dashboard/franchise-ship-from-store-page.tsx
+++ b/src/pages/franchise/dashboard/franchise-ship-from-store-page.tsx
@@ -4,6 +4,12 @@ import { franchiseCommissionsColumns } from "@/components/feature-specific/ship-
 import { franchiseShipFromOrdersColumns } from "@/components/feature-specific/ship-from-store/franchise-ship-from-orders-columns";
 import { franchiseShipFromStoreColumns } from "@/components/feature-specific/ship-from-store/franchise-ship-from-store-columns";
 import { ShipFromStoreDialog } from "@/components/feature-specific/ship-from-store/ship-from-store-dialog";
+import { CompanyFranchiseWooRefundDetailDialog } from "@/components/feature-specific/woo-refund/company-franchise-woo-refund-detail-dialog";
+import { createFranchiseWooRefundsColumns } from "@/components/feature-specific/woo-refund/franchise-woo-refunds-columns";
+import {
+  effectiveReimbursementStatus,
+  totalOutstandingReimbursement,
+} from "@/components/feature-specific/woo-refund/woo-refund-reimbursement";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,14 +19,23 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { DataTable } from "@/components/ui/data-table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { FranchiseCommissionsResponse } from "@/models/data/franchise-commission.model";
+import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
 import { WooOrder } from "@/models/data/woo-order.model";
 import {
   listFranchiseCommissions,
   listFranchiseWooOrders,
 } from "@/services/franchise-service";
 import { listShipFromStoreFranchise } from "@/services/ship-from-store-service";
+import { listFranchiseWooRefunds } from "@/services/woo-refund-service";
 import { useQuery } from "@tanstack/react-query";
 import {
   CheckCircle2,
@@ -28,14 +43,16 @@ import {
   Package,
   Plus,
   Receipt,
+  RotateCcw,
   ShoppingBag,
   XCircle,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useSearchParams } from "react-router-dom";
 
-const TAB_VALUES = ["shipments", "orders", "commissions"] as const;
+const TAB_VALUES = ["shipments", "orders", "commissions", "refunds"] as const;
 type TabValue = (typeof TAB_VALUES)[number];
 
 function isTabValue(value: string | null): value is TabValue {
@@ -60,6 +77,17 @@ export default function FranchiseShipFromStorePage() {
     : "shipments";
   const [activeTab, setActiveTab] = useState<TabValue>(initialTab);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [detailRefund, setDetailRefund] = useState<FranchiseWooRefund | null>(
+    null
+  );
+  const [reimbursementFilter, setReimbursementFilter] = useState<string>("all");
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    if (isTabValue(tab) && tab !== activeTab) {
+      setActiveTab(tab);
+    }
+  }, [searchParams, activeTab]);
 
   const handleTabChange = (value: string) => {
     if (!isTabValue(value)) return;
@@ -87,12 +115,43 @@ export default function FranchiseShipFromStorePage() {
     enabled: !!franchise,
   });
 
+  const refundsQuery = useQuery({
+    queryKey: ["franchise-woo-refunds", reimbursementFilter],
+    queryFn: () =>
+      listFranchiseWooRefunds({
+        reimbursement_status:
+          reimbursementFilter === "all" ? undefined : reimbursementFilter,
+        limit: 200,
+      }),
+    enabled: !!franchise,
+  });
+
+  const allRefundsForOutstandingQuery = useQuery({
+    queryKey: ["franchise-woo-refunds-outstanding"],
+    queryFn: () => listFranchiseWooRefunds({ limit: 500 }),
+    enabled: !!franchise,
+  });
+
   const shipments = shipmentsQuery.data?.data ?? [];
   const orders: WooOrder[] = ordersQuery.data?.data ?? [];
   const commissionsData: FranchiseCommissionsResponse | undefined =
     commissionsQuery.data?.data;
   const commissions = commissionsData?.commissions ?? [];
   const totals = commissionsData?.totals;
+  const refunds = refundsQuery.data?.data ?? [];
+
+  const refundColumns = useMemo(
+    () => createFranchiseWooRefundsColumns(setDetailRefund),
+    []
+  );
+
+  const pendingPaybackTotal = useMemo(
+    () =>
+      totalOutstandingReimbursement(
+        allRefundsForOutstandingQuery.data?.data ?? []
+      ),
+    [allRefundsForOutstandingQuery.data]
+  );
 
   const orderStats = useMemo(() => {
     const open = orders.filter((order) => {
@@ -119,11 +178,37 @@ export default function FranchiseShipFromStorePage() {
             </span>
           </div>
         </div>
-        <Button onClick={() => setCreateDialogOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          New shipment
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" asChild>
+            <Link to="../woo-refund">
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Web order refund
+            </Link>
+          </Button>
+          {activeTab === "shipments" && (
+            <Button onClick={() => setCreateDialogOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              New shipment
+            </Button>
+          )}
+        </div>
       </div>
+
+      {activeTab === "refunds" && (
+        <Select
+          value={reimbursementFilter}
+          onValueChange={setReimbursementFilter}
+        >
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Company payback" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All refunds</SelectItem>
+            <SelectItem value="pending">Awaiting company payment</SelectItem>
+            <SelectItem value="paid">Paid by company</SelectItem>
+          </SelectContent>
+        </Select>
+      )}
 
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <SummaryCard
@@ -173,6 +258,13 @@ export default function FranchiseShipFromStorePage() {
             Commissions
             <Badge variant="secondary" className="ml-2">
               {commissions.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="refunds">
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Refunds
+            <Badge variant="secondary" className="ml-2">
+              {refunds.length}
             </Badge>
           </TabsTrigger>
         </TabsList>
@@ -267,7 +359,64 @@ export default function FranchiseShipFromStorePage() {
             </CardContent>
           </Card>
         </TabsContent>
+
+        <TabsContent value="refunds" className="mt-4 space-y-3">
+          {pendingPaybackTotal > 0 && reimbursementFilter !== "paid" && (
+            <Card>
+              <CardContent className="pt-4">
+                <p className="text-sm text-muted-foreground">
+                  Company still owes you (cash you paid to customers)
+                </p>
+                <p className="text-2xl font-semibold">
+                  {formatCurrency(pendingPaybackTotal)}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0">
+              <div>
+                <CardTitle className="text-base">Refunds at my store</CardTitle>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Returns processed here. Company payback status is updated by
+                  headquarters.
+                </p>
+              </div>
+              <Button variant="outline" size="sm" asChild>
+                <Link to="../woo-refund">
+                  <Plus className="mr-2 h-4 w-4" />
+                  New refund
+                </Link>
+              </Button>
+            </CardHeader>
+            <CardContent>
+              {refundsQuery.isLoading ? (
+                <p className="text-sm text-muted-foreground">Loading refunds...</p>
+              ) : refundsQuery.isError ? (
+                <p className="text-sm text-destructive">Failed to load refunds.</p>
+              ) : refunds.length === 0 ? (
+                <EmptyState
+                  icon={<RotateCcw className="h-6 w-6" />}
+                  title="No refunds yet"
+                  description="Web order returns recorded at your store will appear here."
+                />
+              ) : (
+                <DataTable
+                  data={refunds}
+                  searchColumn="order"
+                  columns={refundColumns}
+                />
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
       </Tabs>
+
+      <CompanyFranchiseWooRefundDetailDialog
+        refund={detailRefund}
+        open={!!detailRefund}
+        onOpenChange={(open) => !open && setDetailRefund(null)}
+      />
 
       <ShipFromStoreDialog
         open={createDialogOpen}

--- a/src/pages/franchise/dashboard/franchise-woo-refund-page.tsx
+++ b/src/pages/franchise/dashboard/franchise-woo-refund-page.tsx
@@ -1,0 +1,17 @@
+import { RootState } from "@/app/store";
+import WooRefundPage from "@/components/feature-specific/woo-refund/woo-refund-page";
+import { useSelector } from "react-redux";
+
+export default function FranchiseWooRefundPage() {
+  const franchise = useSelector((state: RootState) => state.franchise.franchise);
+  if (!franchise) return null;
+
+  return (
+    <WooRefundPage
+      scope="franchise"
+      defaultFranchiseId={franchise.ID}
+      backLabel="Menu"
+      title="Web order refund"
+    />
+  );
+}

--- a/src/pages/moderator/dashboard/user-menu-page.tsx
+++ b/src/pages/moderator/dashboard/user-menu-page.tsx
@@ -114,6 +114,11 @@ const quickMenu = [
     href: "franchise-fulfillment",
   },
   {
+    label: "Web order refund",
+    icon: ReceiptText,
+    href: "woo-refund",
+  },
+  {
     label: "CRM Customers",
     icon: Users,
     href: "crm/customers",

--- a/src/services/woo-refund-service.ts
+++ b/src/services/woo-refund-service.ts
@@ -1,0 +1,160 @@
+import { baseUrl } from "@/app/constants";
+import {
+  CreateFranchiseWooRefundRequest,
+  FranchiseLedgerEntry,
+  FranchiseWooRefund,
+  FranchiseWooRefundPreview,
+  WooOrderSearchHit,
+} from "@/models/data/franchise-woo-refund.model";
+import { APIResponse } from "@/models/responses/api-response.model";
+
+const authHeaders = () => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${localStorage.getItem("token")}`,
+});
+
+async function parseError(response: Response, fallback: string): Promise<never> {
+  const errorData = await response.json().catch(() => ({}));
+  throw new Error(errorData.message || errorData.error?.description || fallback);
+}
+
+export type WooRefundApiScope = "company" | "franchise";
+
+function basePath(scope: WooRefundApiScope): string {
+  return scope === "company" ? `${baseUrl}/franchise-fulfillment` : `${baseUrl}/franchise`;
+}
+
+export const searchWooOrdersForRefund = async (
+  scope: WooRefundApiScope,
+  params: { tracking_number?: string; phone?: string }
+): Promise<APIResponse<WooOrderSearchHit[]>> => {
+  const qs = new URLSearchParams();
+  if (params.tracking_number?.trim()) {
+    qs.set("tracking_number", params.tracking_number.trim());
+  }
+  if (params.phone?.trim()) {
+    qs.set("phone", params.phone.trim());
+  }
+  const response = await fetch(`${basePath(scope)}/woo-orders/search?${qs}`, {
+    method: "GET",
+    headers: authHeaders(),
+  });
+  if (!response.ok) {
+    await parseError(response, "Search failed.");
+  }
+  return response.json();
+};
+
+export const getWooRefundPreview = async (
+  scope: WooRefundApiScope,
+  wooOrderId: number
+): Promise<APIResponse<FranchiseWooRefundPreview>> => {
+  const response = await fetch(
+    `${basePath(scope)}/woo-orders/${wooOrderId}/refund-preview`,
+    { method: "GET", headers: authHeaders() }
+  );
+  if (!response.ok) {
+    await parseError(response, "Failed to load refund preview.");
+  }
+  return response.json();
+};
+
+export const createFranchiseWooRefund = async (
+  scope: WooRefundApiScope,
+  body: CreateFranchiseWooRefundRequest
+): Promise<APIResponse<unknown>> => {
+  const response = await fetch(`${basePath(scope)}/woo-refunds`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    await parseError(response, "Failed to create refund.");
+  }
+  return response.json();
+};
+
+export const listFranchiseWooRefunds = async (params?: {
+  reimbursement_status?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<APIResponse<FranchiseWooRefund[]>> => {
+  const qs = new URLSearchParams();
+  if (params?.reimbursement_status) {
+    qs.set("reimbursement_status", params.reimbursement_status);
+  }
+  qs.set("limit", String(params?.limit ?? 100));
+  if (params?.offset != null) {
+    qs.set("offset", String(params.offset));
+  }
+  const response = await fetch(`${baseUrl}/franchise/woo-refunds?${qs}`, {
+    method: "GET",
+    headers: authHeaders(),
+  });
+  if (!response.ok) {
+    await parseError(response, "Failed to load refunds.");
+  }
+  return response.json();
+};
+
+export const listCompanyWooRefunds = async (params?: {
+  franchise_id?: number;
+  woo_order_id?: number;
+  reimbursement_status?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<APIResponse<FranchiseWooRefund[]>> => {
+  const qs = new URLSearchParams();
+  if (params?.franchise_id != null) {
+    qs.set("franchise_id", String(params.franchise_id));
+  }
+  if (params?.woo_order_id != null) {
+    qs.set("woo_order_id", String(params.woo_order_id));
+  }
+  if (params?.reimbursement_status) {
+    qs.set("reimbursement_status", params.reimbursement_status);
+  }
+  qs.set("limit", String(params?.limit ?? 100));
+  if (params?.offset != null) {
+    qs.set("offset", String(params.offset));
+  }
+  const response = await fetch(
+    `${baseUrl}/franchise-fulfillment/woo-refunds?${qs}`,
+    { method: "GET", headers: authHeaders() }
+  );
+  if (!response.ok) {
+    await parseError(response, "Failed to load refunds.");
+  }
+  return response.json();
+};
+
+export const markCompanyWooRefundReimbursed = async (
+  refundId: number,
+  body?: { payment_reference?: string }
+): Promise<APIResponse<FranchiseWooRefund>> => {
+  const response = await fetch(
+    `${baseUrl}/franchise-fulfillment/woo-refunds/${refundId}/mark-reimbursed`,
+    {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify(body ?? {}),
+    }
+  );
+  if (!response.ok) {
+    await parseError(response, "Failed to record reimbursement.");
+  }
+  return response.json();
+};
+
+export const listFranchiseLedgerEntries = async (): Promise<
+  APIResponse<FranchiseLedgerEntry[]>
+> => {
+  const response = await fetch(`${baseUrl}/franchise/ledger-entries?limit=100`, {
+    method: "GET",
+    headers: authHeaders(),
+  });
+  if (!response.ok) {
+    await parseError(response, "Failed to load ledger.");
+  }
+  return response.json();
+};


### PR DESCRIPTION


- Added routing for web order refunds in the application, including new pages for company and franchise refunds.
- Introduced components for managing and displaying refund details, including dialogs for recording payments and viewing refund summaries.
- Enhanced the product variant combobox to support displaying additional variant information.
- Implemented utility functions for calculating refund amounts and managing exchange details.
- Updated the franchise menu to include a link to the new web order refund feature, improving navigation.
- Added comprehensive handling for refund data, including reimbursement statuses and exchange calculations, streamlining the refund process.