### PR TITLE
feat(franchise-orders): add 'not_available' status to franchise order management

### DIFF
--- a/src/components/feature-specific/ship-from-store/company-franchise-fulfillment-orders-columns.tsx
+++ b/src/components/feature-specific/ship-from-store/company-franchise-fulfillment-orders-columns.tsx
@@ -22,6 +22,7 @@ const FRANCHISE_ORDER_STATUS_LABELS: Record<FranchiseOrderStatus, string> = {
   pending: "Pending",
   packed: "Packed",
   dispatched: "Dispatched",
+  not_available: "Not Available",
 };
 
 function OrderNumberCell({ order }: { order: WooOrder }) {

--- a/src/components/feature-specific/ship-from-store/franchise-ship-from-orders-columns.tsx
+++ b/src/components/feature-specific/ship-from-store/franchise-ship-from-orders-columns.tsx
@@ -52,13 +52,24 @@ const FRANCHISE_ORDER_STATUS_LABELS: Record<FranchiseOrderStatus, string> = {
   pending: "Pending",
   packed: "Packed",
   dispatched: "Dispatched",
+  not_available: "Not Available",
 };
 
 const STATUS_RANK: Record<FranchiseOrderStatus, number> = {
   pending: 1,
   packed: 2,
   dispatched: 3,
+  not_available: 0,
 };
+
+function isFranchiseStatusOptionDisabled(
+  option: FranchiseOrderStatus,
+  current: FranchiseOrderStatus
+): boolean {
+  if (current === "not_available") return option !== "not_available";
+  if (option === "not_available") return current === "dispatched";
+  return STATUS_RANK[option] < STATUS_RANK[current];
+}
 
 function FranchiseStatusCell({ order }: { order: WooOrder }) {
   const queryClient = useQueryClient();
@@ -66,7 +77,6 @@ function FranchiseStatusCell({ order }: { order: WooOrder }) {
   const current = isFranchiseOrderStatus(order.franchise_order_status)
     ? order.franchise_order_status
     : "pending";
-  const currentRank = STATUS_RANK[current];
 
   const mutation = useMutation({
     mutationFn: (status: FranchiseOrderStatus) =>
@@ -104,7 +114,7 @@ function FranchiseStatusCell({ order }: { order: WooOrder }) {
           <SelectItem
             key={status}
             value={status}
-            disabled={STATUS_RANK[status] < currentRank}
+            disabled={isFranchiseStatusOptionDisabled(status, current)}
           >
             {FRANCHISE_ORDER_STATUS_LABELS[status]}
           </SelectItem>

--- a/src/models/data/woo-order.model.ts
+++ b/src/models/data/woo-order.model.ts
@@ -61,16 +61,22 @@ export interface WooOrder {
   franchise_order_status?: FranchiseOrderStatus | string;
 }
 
-export type FranchiseOrderStatus = "pending" | "packed" | "dispatched";
+export type FranchiseOrderStatus = "pending" | "packed" | "dispatched" | "not_available";
 
 export const FRANCHISE_ORDER_STATUSES: FranchiseOrderStatus[] = [
   "pending",
   "packed",
   "dispatched",
+  "not_available",
 ];
 
 export function isFranchiseOrderStatus(value: string | undefined | null): value is FranchiseOrderStatus {
-  return value === "pending" || value === "packed" || value === "dispatched";
+  return (
+    value === "pending" ||
+    value === "packed" ||
+    value === "dispatched" ||
+    value === "not_available"
+  );
 }
 
 export interface YalidineOrderHistory {

--- a/src/pages/dashboard/company/company-franchise-fulfillment-page.tsx
+++ b/src/pages/dashboard/company/company-franchise-fulfillment-page.tsx
@@ -100,6 +100,7 @@ const FRANCHISE_STATUS_LABELS: Record<FranchiseOrderStatus, string> = {
   pending: "Pending",
   packed: "Packed",
   dispatched: "Dispatched",
+  not_available: "Not Available",
 };
 
 export default function CompanyFranchiseFulfillmentPage() {

--- a/src/services/franchise-service.ts
+++ b/src/services/franchise-service.ts
@@ -113,7 +113,7 @@ export const listFranchiseWooOrders = async (): Promise<APIResponse<any[]>> => {
 
 export const updateFranchiseOrderStatus = async (
   orderId: number,
-  status: "pending" | "packed" | "dispatched"
+  status: "pending" | "packed" | "dispatched" | "not_available"
 ): Promise<APIResponse<any>> => {
   const response = await fetch(`${baseUrl}/franchise/woo-orders/${orderId}/status`, {
     method: "PATCH",


### PR DESCRIPTION

- Introduced 'not_available' status to the FranchiseOrderStatus type and updated related components to handle this new status.
- Enhanced the status selection logic to accommodate the new 'not_available' option, improving order management capabilities.
- Updated relevant UI components and API services to support the new status, ensuring consistency across the application.