### PR TITLE
feat(franchise-commissions): implement company franchise commissions table and enhance commission status handling

### DIFF
--- a/src/components/feature-specific/ship-from-store/company-franchise-commissions-table.tsx
+++ b/src/components/feature-specific/ship-from-store/company-franchise-commissions-table.tsx
@@ -1,0 +1,117 @@
+import { companyFranchiseCommissionsColumns } from "@/components/feature-specific/ship-from-store/company-franchise-commissions-columns";
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/ui/data-table";
+import { FranchiseCommission } from "@/models/data/franchise-commission.model";
+import { CheckCircle2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+const formatDZD = (n: number) =>
+  new Intl.NumberFormat("en-DZ", {
+    style: "currency",
+    currency: "DZD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+export function canMarkCommissionPaid(commission: FranchiseCommission): boolean {
+  return commission.status === "approved";
+}
+
+type Props = {
+  commissions: FranchiseCommission[];
+  onRequestMarkPaid: (commissions: FranchiseCommission[]) => void;
+  isMarkingPaid?: boolean;
+};
+
+export function CompanyFranchiseCommissionsTable({
+  commissions,
+  onRequestMarkPaid,
+  isMarkingPaid,
+}: Props) {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const payableCommissions = useMemo(
+    () => commissions.filter(canMarkCommissionPaid),
+    [commissions]
+  );
+
+  const selectedCommissions = useMemo(
+    () =>
+      commissions.filter(
+        (c) => selectedIds.includes(String(c.ID)) && canMarkCommissionPaid(c)
+      ),
+    [commissions, selectedIds]
+  );
+
+  const selectedTotal = useMemo(
+    () =>
+      selectedCommissions.reduce((sum, c) => sum + (c.total_amount ?? 0), 0),
+    [selectedCommissions]
+  );
+
+  const selectAllPayable = () => {
+    setSelectedIds(payableCommissions.map((c) => String(c.ID)));
+  };
+
+  const clearSelection = () => setSelectedIds([]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2">
+        <span className="text-sm text-muted-foreground mr-1">
+          {payableCommissions.length} approved awaiting payout
+          {selectedCommissions.length > 0 && (
+            <>
+              {" · "}
+              <span className="text-foreground font-medium">
+                {selectedCommissions.length} selected ({formatDZD(selectedTotal)})
+              </span>
+            </>
+          )}
+        </span>
+        <div className="flex flex-wrap gap-2 ml-auto">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={selectAllPayable}
+            disabled={payableCommissions.length === 0}
+          >
+            Select all
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={clearSelection}
+            disabled={selectedIds.length === 0}
+          >
+            Unselect all
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => onRequestMarkPaid(selectedCommissions)}
+            disabled={selectedCommissions.length === 0 || isMarkingPaid}
+          >
+            <CheckCircle2 className="mr-2 h-4 w-4" />
+            Mark as paid
+            {selectedCommissions.length > 0
+              ? ` (${selectedCommissions.length})`
+              : ""}
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <DataTable
+          data={commissions}
+          columns={companyFranchiseCommissionsColumns}
+          selectedRows={selectedIds}
+          setSelectedRows={setSelectedIds}
+          getRowId={(row) => String(row.ID)}
+          isRowSelectable={canMarkCommissionPaid}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/feature-specific/ship-from-store/franchise-commission-details-dialog.tsx
+++ b/src/components/feature-specific/ship-from-store/franchise-commission-details-dialog.tsx
@@ -25,11 +25,18 @@ function statusVariant(status: string): "default" | "secondary" | "outline" | "d
   switch (status) {
     case "approved":
       return "default";
+    case "paid":
+      return "outline";
     case "cancelled":
       return "destructive";
     default:
       return "secondary";
   }
+}
+
+function statusLabel(status: string) {
+  if (status === "paid") return "Paid";
+  return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
@@ -78,7 +85,7 @@ export function FranchiseCommissionDetailsDialog({
             <DialogTitle className="flex flex-wrap items-center gap-2">
               Commission #{commission.ID}
               <Badge variant={statusVariant(commission.status)}>
-                {commission.status}
+                {statusLabel(commission.status)}
               </Badge>
             </DialogTitle>
             <DialogDescription>

--- a/src/components/feature-specific/ship-from-store/franchise-commissions-columns.tsx
+++ b/src/components/feature-specific/ship-from-store/franchise-commissions-columns.tsx
@@ -17,6 +17,8 @@ function statusVariant(status: string): "default" | "secondary" | "outline" | "d
   switch (status) {
     case "approved":
       return "default";
+    case "paid":
+      return "outline";
     case "cancelled":
       return "destructive";
     case "pending":
@@ -26,6 +28,7 @@ function statusVariant(status: string): "default" | "secondary" | "outline" | "d
 }
 
 function statusLabel(status: string) {
+  if (status === "paid") return "Paid";
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 

--- a/src/models/data/franchise-commission.model.ts
+++ b/src/models/data/franchise-commission.model.ts
@@ -1,6 +1,6 @@
 import { ConfirmedOrderItem, WooOrder } from "@/models/data/woo-order.model";
 
-export type FranchiseCommissionStatus = "pending" | "approved" | "cancelled";
+export type FranchiseCommissionStatus = "pending" | "approved" | "paid" | "cancelled";
 
 export interface FranchiseCommission {
   ID: number;
@@ -25,6 +25,7 @@ export interface FranchiseCommission {
 export interface FranchiseCommissionTotals {
   pending_amount: number;
   approved_amount: number;
+  paid_amount: number;
   cancelled_amount: number;
   total_amount: number;
 }

--- a/src/pages/dashboard/company/company-franchise-fulfillment-page.tsx
+++ b/src/pages/dashboard/company/company-franchise-fulfillment-page.tsx
@@ -4,7 +4,7 @@ import ConfirmDialog from "@/components/common/confirm-dialog";
 import { CompanyShipFromStoreCreateDialog } from "@/components/feature-specific/ship-from-store/company-ship-from-store-create-dialog";
 import { CompanyShipFromStoreEditDialog } from "@/components/feature-specific/ship-from-store/company-ship-from-store-edit-dialog";
 import { createCompanyShipFromStoreColumns } from "@/components/feature-specific/ship-from-store/company-ship-from-store-columns";
-import { companyFranchiseCommissionsColumns } from "@/components/feature-specific/ship-from-store/company-franchise-commissions-columns";
+import { CompanyFranchiseCommissionsTable } from "@/components/feature-specific/ship-from-store/company-franchise-commissions-table";
 import { companyFranchiseFulfillmentOrdersColumns } from "@/components/feature-specific/ship-from-store/company-franchise-fulfillment-orders-columns";
 import { CompanyFranchiseWooRefundDetailDialog } from "@/components/feature-specific/woo-refund/company-franchise-woo-refund-detail-dialog";
 import { CompanyFranchiseWooRefundsTable } from "@/components/feature-specific/woo-refund/company-franchise-woo-refunds-table";
@@ -49,6 +49,7 @@ import { FranchiseWooRefund } from "@/models/data/franchise-woo-refund.model";
 import { WooOrder } from "@/models/data/woo-order.model";
 import { getMyCompanyFranchises } from "@/services/franchise-service";
 import {
+  bulkMarkFranchiseCommissionsPaid,
   FranchiseFulfillmentListParams,
   listCompanyFranchiseFulfillmentCommissions,
   listCompanyFranchiseFulfillmentOrders,
@@ -96,7 +97,14 @@ const formatCurrency = (amount: number) =>
     maximumFractionDigits: 0,
   }).format(amount);
 
-const COMMISSION_STATUSES = ["pending", "approved", "cancelled"] as const;
+const COMMISSION_STATUSES = ["pending", "approved", "paid", "cancelled"] as const;
+
+const COMMISSION_STATUS_LABELS: Record<(typeof COMMISSION_STATUSES)[number], string> = {
+  pending: "Pending",
+  approved: "Approved",
+  paid: "Paid",
+  cancelled: "Cancelled",
+};
 
 const FRANCHISE_STATUS_LABELS: Record<FranchiseOrderStatus, string> = {
   pending: "Pending",
@@ -270,6 +278,32 @@ export default function CompanyFranchiseFulfillmentPage() {
         limit: 500,
       }),
     enabled: !!companyId,
+  });
+
+  const markPaidMutation = useMutation({
+    mutationFn: (commissionIds: number[]) =>
+      bulkMarkFranchiseCommissionsPaid(commissionIds, companyId),
+    onSuccess: (res) => {
+      const updated = res.data?.updated_count ?? 0;
+      const skipped = res.data?.skipped_count ?? 0;
+      toast({
+        title: "Commissions marked as paid",
+        description:
+          skipped > 0
+            ? `${updated} updated, ${skipped} skipped (not approved or not in your company).`
+            : `${updated} commission${updated === 1 ? "" : "s"} marked as paid.`,
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["company-franchise-fulfillment-commissions"],
+      });
+    },
+    onError: (e: Error) => {
+      toast({
+        title: "Could not mark as paid",
+        description: e.message,
+        variant: "destructive",
+      });
+    },
   });
 
   const markReimbursedMutation = useMutation({
@@ -548,7 +582,7 @@ export default function CompanyFranchiseFulfillmentPage() {
               <SelectItem value="all">All commission statuses</SelectItem>
               {COMMISSION_STATUSES.map((s) => (
                 <SelectItem key={s} value={s}>
-                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                  {COMMISSION_STATUS_LABELS[s]}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -696,9 +730,12 @@ export default function CompanyFranchiseFulfillmentPage() {
                   description="No commission rows match your filters."
                 />
               ) : (
-                <DataTable
-                  data={commissions}
-                  columns={companyFranchiseCommissionsColumns}
+                <CompanyFranchiseCommissionsTable
+                  commissions={commissions}
+                  onRequestMarkPaid={(rows) =>
+                    markPaidMutation.mutate(rows.map((r) => r.ID))
+                  }
+                  isMarkingPaid={markPaidMutation.isPending}
                 />
               )}
             </CardContent>
@@ -893,8 +930,9 @@ function CommissionsTotals({
   totals: FranchiseCommissionsResponse["totals"] | undefined;
 }) {
   if (!totals) return null;
+  const paidAmount = totals.paid_amount ?? 0;
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
       <SummaryCard
         icon={<Coins className="h-4 w-4 text-amber-500" />}
         label="Pending"
@@ -904,6 +942,13 @@ function CommissionsTotals({
         icon={<CheckCircle2 className="h-4 w-4 text-emerald-500" />}
         label="Approved"
         value={formatCurrency(totals.approved_amount)}
+        hint="Awaiting payout"
+      />
+      <SummaryCard
+        icon={<CheckCircle2 className="h-4 w-4 text-teal-600" />}
+        label="Paid"
+        value={formatCurrency(paidAmount)}
+        hint="Paid to franchises"
       />
       <SummaryCard
         icon={<XCircle className="h-4 w-4 text-rose-500" />}
@@ -914,7 +959,7 @@ function CommissionsTotals({
         icon={<Receipt className="h-4 w-4 text-primary" />}
         label="Net earnings"
         value={formatCurrency(totals.total_amount)}
-        hint="Approved + pending"
+        hint="Approved + pending (excludes paid)"
       />
     </div>
   );

--- a/src/pages/franchise/dashboard/franchise-ship-from-store-page.tsx
+++ b/src/pages/franchise/dashboard/franchise-ship-from-store-page.tsx
@@ -461,8 +461,9 @@ function CommissionsTotals({
   totals: FranchiseCommissionsResponse["totals"] | undefined;
 }) {
   if (!totals) return null;
+  const paidAmount = totals.paid_amount ?? 0;
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
       <SummaryCard
         icon={<Coins className="h-4 w-4 text-amber-500" />}
         label="Pending"
@@ -472,6 +473,13 @@ function CommissionsTotals({
         icon={<CheckCircle2 className="h-4 w-4 text-emerald-500" />}
         label="Approved"
         value={formatCurrency(totals.approved_amount)}
+        hint="Awaiting payout"
+      />
+      <SummaryCard
+        icon={<CheckCircle2 className="h-4 w-4 text-teal-600" />}
+        label="Paid"
+        value={formatCurrency(paidAmount)}
+        hint="Paid by company"
       />
       <SummaryCard
         icon={<XCircle className="h-4 w-4 text-rose-500" />}
@@ -482,7 +490,7 @@ function CommissionsTotals({
         icon={<Receipt className="h-4 w-4 text-primary" />}
         label="Net earnings"
         value={formatCurrency(totals.total_amount)}
-        hint="Approved + pending"
+        hint="Approved + pending (excludes paid)"
       />
     </div>
   );

--- a/src/services/franchise-fulfillment-service.ts
+++ b/src/services/franchise-fulfillment-service.ts
@@ -81,3 +81,27 @@ export const listCompanyFranchiseFulfillmentCommissions = async (
   }
   return response.json();
 };
+
+export interface BulkMarkCommissionsPaidResult {
+  updated_count: number;
+  skipped_count: number;
+}
+
+export const bulkMarkFranchiseCommissionsPaid = async (
+  ids: number[],
+  companyId?: number
+): Promise<APIResponse<BulkMarkCommissionsPaidResult>> => {
+  const search = companyId != null ? `?company_id=${companyId}` : "";
+  const response = await fetch(
+    `${baseUrl}/franchise-fulfillment/commissions/bulk-status${search}`,
+    {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ids, status: "paid" }),
+    }
+  );
+  if (!response.ok) {
+    await parseError(response, "Failed to mark commissions as paid.");
+  }
+  return response.json();
+};


### PR DESCRIPTION


- Added CompanyFranchiseCommissionsTable component for displaying and managing franchise commissions.
- Introduced functionality to mark commissions as paid, including bulk marking and UI updates.
- Enhanced commission status handling by adding 'paid' status to the FranchiseCommission model and updating related components for improved visibility.
- Updated dashboard and details dialog to reflect new commission statuses and totals, improving user experience in commission management.