### PR TITLE
fix(product-update-form): improve handling of franchise ship commission defaults

### DIFF
--- a/src/components/feature-specific/company-products/update-product-form.tsx
+++ b/src/components/feature-specific/company-products/update-product-form.tsx
@@ -46,7 +46,10 @@ function getProductFormValues(product: Product): UpdateProductSchema {
     pairable: product.pairable ?? false,
     combinable: product.combinable ?? false,
     is_active: product.is_active,
-    franchise_ship_commission: product.franchise_ship_commission ?? 800,
+    franchise_ship_commission:
+      product.franchise_ship_commission !== undefined
+        ? product.franchise_ship_commission
+        : 800,
   };
 }
 
@@ -88,9 +91,11 @@ export default function MyForm({ product }: Props) {
     updateProductMutation({
       ...values,
       franchise_ship_commission:
-        values.franchise_ship_commission ??
-        product.franchise_ship_commission ??
-        800,
+        values.franchise_ship_commission !== undefined
+          ? values.franchise_ship_commission
+          : product.franchise_ship_commission !== undefined
+            ? product.franchise_ship_commission
+            : 800,
     });
   }
 
@@ -204,7 +209,9 @@ export default function MyForm({ product }: Props) {
                         placeholder="800"
                         type="number"
                         min={0}
-                        value={field.value ?? 800}
+                        value={
+                          field.value !== undefined ? field.value : 800
+                        }
                         onChange={(e) =>
                           field.onChange(Number(e.target.value))
                         }


### PR DESCRIPTION


- Updated the logic for setting the default value of franchise ship commission in the product update form to ensure it correctly falls back to 800 when not explicitly provided.
- Enhanced the form submission logic to maintain consistency in how franchise ship commission values are handled, improving overall reliability.