### PR TITLE
feat(broken-items): add declarations and transfers management for franchises and moderators

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -54,6 +54,7 @@ import CompanySalesPage from "@/pages/dashboard/company/company-sales-page";
 import CompanySalesSwitchPage from "@/pages/dashboard/company/company-sales-switch-page";
 import CompanyStatsPage from "@/pages/dashboard/company/company-stats-page";
 import CompanyBrokenItemsTransfersPage from "@/pages/dashboard/company/company-broken-items-transfers-page";
+import CompanyBrokenItemsDeclarationsPage from "@/pages/dashboard/company/company-broken-items-declarations-page";
 import CompanyFranchiseFulfillmentPage from "@/pages/dashboard/company/company-franchise-fulfillment-page";
 import CompanyWooRefundPage from "@/pages/dashboard/company/company-woo-refund-page";
 import CompanyFranchiseShipFromStorePage from "@/pages/dashboard/company/company-franchise-ship-from-store-page";
@@ -109,6 +110,7 @@ import HomePage from "@/pages/home-page";
 import UserLoginPage from "@/pages/moderator/auth/login-page";
 import ModeratorMobilePage from "@/pages/moderator/dashboard/moderator-mobile-page";
 import ModeratorBrokenItemsTransfersPage from "@/pages/moderator/dashboard/moderator-broken-items-transfers-page";
+import ModeratorBrokenItemsDeclarationsPage from "@/pages/moderator/dashboard/moderator-broken-items-declarations-page";
 import ModeratorStockAlertsHistoryPage from "@/pages/moderator/dashboard/moderator-stock-alerts-history-page";
 import ModeratorStockAlertsNotificationsPage from "@/pages/moderator/dashboard/moderator-stock-alerts-notifications-page";
 import ModeratorStockAlertsPage from "@/pages/moderator/dashboard/moderator-stock-alerts-page";
@@ -230,6 +232,7 @@ export default function AppRouter() {
               <Route path="notifications" element={<ModeratorStockAlertsNotificationsPage />} />
             </Route>
             <Route path="broken-items-transfers" element={<ModeratorBrokenItemsTransfersPage />} />
+            <Route path="broken-items-declarations" element={<ModeratorBrokenItemsDeclarationsPage />} />
             <Route
               path="franchise-fulfillment"
               element={<CompanyFranchiseFulfillmentPage />}
@@ -332,6 +335,7 @@ export default function AppRouter() {
                 <Route path="notifications" element={<CompanyStockAlertsNotificationsPage />} />
               </Route>
               <Route path="broken-items-transfers" element={<CompanyBrokenItemsTransfersPage />} />
+              <Route path="broken-items-declarations" element={<CompanyBrokenItemsDeclarationsPage />} />
               <Route
                 path="franchise-fulfillment"
                 element={<CompanyFranchiseFulfillmentPage />}

--- a/src/components/feature-specific/broken-items/broken-items-declarations-page-body.tsx
+++ b/src/components/feature-specific/broken-items/broken-items-declarations-page-body.tsx
@@ -1,0 +1,313 @@
+import { DeclarationsList } from "@/components/feature-specific/broken-items/declarations-list";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { BrokenItemListItem, BrokenItemListResponse } from "@/models/data/broken-item.model";
+import { getBrokenItems, recoverBrokenItem } from "@/services/broken-items-service";
+import { getMyCompanyFranchises } from "@/services/franchise-service";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, RefreshCw, RotateCcw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+interface BrokenItemsDeclarationsPageBodyProps {
+  companyId: number;
+}
+
+const PAGE_SIZE = 20;
+
+export default function BrokenItemsDeclarationsPageBody({
+  companyId,
+}: BrokenItemsDeclarationsPageBodyProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [franchiseFilter, setFranchiseFilter] = useState<string>("all");
+  const [page, setPage] = useState(1);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const transfersPath = location.pathname.includes("/moderator/")
+    ? "/moderator/broken-items-transfers"
+    : `/company/${companyId}/broken-items-transfers`;
+
+  const { data: franchisesData } = useQuery({
+    queryKey: ["company-franchises", companyId],
+    queryFn: () => getMyCompanyFranchises(companyId),
+    enabled: !!companyId,
+  });
+
+  const franchises = franchisesData?.data ?? [];
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: [
+      "broken-items-declarations",
+      companyId,
+      statusFilter,
+      franchiseFilter,
+      page,
+      PAGE_SIZE,
+    ],
+    queryFn: async () => {
+      const response = await getBrokenItems({
+        company_id: companyId,
+        location_type: "franchise",
+        page,
+        limit: PAGE_SIZE,
+        recoverable_only: statusFilter === "recoverable",
+        ...(franchiseFilter !== "all"
+          ? { franchise_id: Number(franchiseFilter) }
+          : {}),
+        ...(statusFilter !== "all" && statusFilter !== "recoverable"
+          ? { status: statusFilter }
+          : {}),
+      });
+      return response.data as BrokenItemListResponse;
+    },
+    enabled: !!companyId,
+  });
+
+  const items = data?.items ?? [];
+  const pagination = data?.pagination;
+  const statusCounts = data?.status_counts;
+
+  const selectableItems = useMemo(
+    () =>
+      items.filter(
+        (item) => item.recoverable_quantity > 0 && !item.blocked_by_pending_transfer
+      ),
+    [items]
+  );
+
+  const { mutate: bulkRecover, isPending: isBulkRecovering } = useMutation({
+    mutationFn: async (targets: BrokenItemListItem[]) => {
+      let successCount = 0;
+      const errors: string[] = [];
+
+      for (const item of targets) {
+        try {
+          await recoverBrokenItem({
+            inventory_item_id: item.inventory_item_id,
+            product_variant_id: item.product_variant_id,
+            recovered_quantity: item.recoverable_quantity,
+          });
+          successCount += 1;
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error";
+          errors.push(message);
+        }
+      }
+
+      return { successCount, errors };
+    },
+    onSuccess: ({ successCount, errors }) => {
+      setSelectedIds(new Set());
+      queryClient.invalidateQueries({ queryKey: ["broken-items-declarations"] });
+      queryClient.invalidateQueries({ queryKey: ["broken-items"] });
+      queryClient.invalidateQueries({ queryKey: ["franchise-inventory"] });
+      queryClient.invalidateQueries({ queryKey: ["company-inventory"] });
+      queryClient.invalidateQueries({ queryKey: ["inventory-total-cost"] });
+
+      toast({
+        title: "Bulk recovery finished",
+        description:
+          errors.length > 0
+            ? `${successCount} recovered, ${errors.length} failed.`
+            : `${successCount} item(s) recovered successfully.`,
+        variant: errors.length > 0 ? "destructive" : "default",
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Bulk recovery failed",
+        description: error.message || "Something went wrong",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value);
+    setPage(1);
+    setSelectedIds(new Set());
+  };
+
+  const handleFranchiseChange = (value: string) => {
+    setFranchiseFilter(value);
+    setPage(1);
+    setSelectedIds(new Set());
+  };
+
+  const handleToggleItem = (id: number) => {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setSelectedIds(next);
+  };
+
+  const handleToggleAll = () => {
+    const allSelected =
+      selectableItems.length > 0 &&
+      selectableItems.every((item) => selectedIds.has(item.ID));
+    if (allSelected) {
+      setSelectedIds(new Set());
+      return;
+    }
+    setSelectedIds(new Set(selectableItems.map((item) => item.ID)));
+  };
+
+  const handleBulkRecover = () => {
+    const targets = items.filter(
+      (item) =>
+        selectedIds.has(item.ID) &&
+        item.recoverable_quantity > 0 &&
+        !item.blocked_by_pending_transfer
+    );
+
+    if (targets.length === 0) {
+      toast({
+        title: "No items selected",
+        description: "Select at least one recoverable declaration.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    bulkRecover(targets);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold">Franchise Declared Quantities</h1>
+            <p className="text-muted-foreground">
+              Review franchise broken-item declarations and restore quantities to
+              sellable inventory
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Select value={franchiseFilter} onValueChange={handleFranchiseChange}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Filter by franchise" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Franchises</SelectItem>
+              {franchises.map((franchise) => (
+                <SelectItem key={franchise.ID} value={String(franchise.ID)}>
+                  {franchise.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={statusFilter} onValueChange={handleStatusChange}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Filter by status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Status</SelectItem>
+              <SelectItem value="recoverable">Recoverable only</SelectItem>
+              <SelectItem value="pending">Pending</SelectItem>
+              <SelectItem value="partially_recovered">Partially recovered</SelectItem>
+              <SelectItem value="fully_recovered">Fully recovered</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button
+            variant="default"
+            onClick={handleBulkRecover}
+            disabled={selectedIds.size === 0 || isBulkRecovering}
+          >
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Recover selected ({selectedIds.size})
+          </Button>
+          <Button variant="outline" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Pending</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-yellow-600">
+              {statusCounts?.pending ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Partially recovered</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-blue-600">
+              {statusCounts?.partially_recovered ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Fully recovered</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-green-600">
+              {statusCounts?.fully_recovered ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Lost</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-red-600">
+              {statusCounts?.lost ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Declarations</CardTitle>
+          <CardDescription>
+            Franchise broken-item declarations
+            {pagination ? ` — showing ${items.length} of ${pagination.total}` : null}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <DeclarationsList
+            items={items}
+            isLoading={isLoading}
+            pagination={pagination}
+            onPageChange={setPage}
+            selectedIds={selectedIds}
+            onToggleItem={handleToggleItem}
+            onToggleAll={handleToggleAll}
+            transfersPath={transfersPath}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/feature-specific/broken-items/broken-items-transfers-page-body.tsx
+++ b/src/components/feature-specific/broken-items/broken-items-transfers-page-body.tsx
@@ -1,0 +1,144 @@
+import { TransfersList } from "@/components/feature-specific/broken-items/transfers-list";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getTransferRequests } from "@/services/broken-items-service";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface BrokenItemsTransfersPageBodyProps {
+  companyId: number;
+}
+
+const PAGE_SIZE = 20;
+
+export default function BrokenItemsTransfersPageBody({
+  companyId,
+}: BrokenItemsTransfersPageBodyProps) {
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["broken-items-transfers", companyId, statusFilter, page, PAGE_SIZE],
+    queryFn: () =>
+      getTransferRequests({
+        company_id: companyId,
+        page,
+        limit: PAGE_SIZE,
+        ...(statusFilter !== "all"
+          ? { status: statusFilter as "pending" | "approved" | "rejected" }
+          : {}),
+      }),
+    enabled: !!companyId,
+  });
+
+  const transfers = data?.data?.transfers ?? [];
+  const pagination = data?.data?.pagination;
+  const statusCounts = data?.data?.status_counts;
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value);
+    setPage(1);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold">Broken Items Transfers</h1>
+            <p className="text-muted-foreground">
+              Review and manage broken item transfer requests from franchises
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Select value={statusFilter} onValueChange={handleStatusChange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Filter by status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Status</SelectItem>
+              <SelectItem value="pending">Pending</SelectItem>
+              <SelectItem value="approved">Approved</SelectItem>
+              <SelectItem value="rejected">Rejected</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button variant="outline" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Pending</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-yellow-600">
+              {statusCounts?.pending ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Approved</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-green-600">
+              {statusCounts?.approved ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Rejected</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription className="text-2xl font-bold text-red-600">
+              {statusCounts?.rejected ?? 0}
+            </CardDescription>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Transfer Requests</CardTitle>
+          <CardDescription>
+            {statusFilter === "all"
+              ? "All transfer requests"
+              : `Transfer requests with status: ${statusFilter}`}
+            {pagination
+              ? ` — showing ${transfers.length} of ${pagination.total}`
+              : null}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TransfersList
+            transfers={transfers}
+            isLoading={isLoading}
+            pagination={pagination}
+            onPageChange={setPage}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/feature-specific/broken-items/declarations-list.tsx
+++ b/src/components/feature-specific/broken-items/declarations-list.tsx
@@ -1,0 +1,293 @@
+import RecoverBrokenItemDialog from "@/components/feature-specific/broken-items/recover-broken-item-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { BrokenItemListItem } from "@/models/data/broken-item.model";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { format } from "date-fns";
+
+interface DeclarationsListProps {
+  items: BrokenItemListItem[];
+  isLoading?: boolean;
+  pagination?: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+  };
+  onPageChange?: (page: number) => void;
+  selectedIds: Set<number>;
+  onToggleItem: (id: number) => void;
+  onToggleAll: () => void;
+  transfersPath: string;
+}
+
+export function DeclarationsList({
+  items,
+  isLoading,
+  pagination,
+  onPageChange,
+  selectedIds,
+  onToggleItem,
+  onToggleAll,
+  transfersPath,
+}: DeclarationsListProps) {
+  const [selectedItem, setSelectedItem] = useState<BrokenItemListItem | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "pending":
+        return (
+          <Badge variant="outline" className="bg-yellow-50 text-yellow-700 border-yellow-300">
+            Pending
+          </Badge>
+        );
+      case "partially_recovered":
+        return (
+          <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-300">
+            Partially recovered
+          </Badge>
+        );
+      case "fully_recovered":
+        return (
+          <Badge variant="outline" className="bg-green-50 text-green-700 border-green-300">
+            Fully recovered
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{status}</Badge>;
+    }
+  };
+
+  const openRecoverDialog = (item: BrokenItemListItem) => {
+    setSelectedItem(item);
+    setDialogOpen(true);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">Loading declarations...</p>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">No franchise declarations found</p>
+      </div>
+    );
+  }
+
+  const currentPage = pagination?.page ?? 1;
+  const totalPages = pagination?.total_pages ?? 1;
+  const selectableItems = items.filter(
+    (item) => item.recoverable_quantity > 0 && !item.blocked_by_pending_transfer
+  );
+  const allSelected =
+    selectableItems.length > 0 &&
+    selectableItems.every((item) => selectedIds.has(item.ID));
+
+  return (
+    <>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10">
+                <Checkbox
+                  checked={allSelected}
+                  onCheckedChange={onToggleAll}
+                  aria-label="Select all recoverable items"
+                />
+              </TableHead>
+              <TableHead>Franchise</TableHead>
+              <TableHead>Variant</TableHead>
+              <TableHead>Declared</TableHead>
+              <TableHead>Recovered</TableHead>
+              <TableHead>Recoverable</TableHead>
+              <TableHead>Sellable</TableHead>
+              <TableHead>Broken</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Reason</TableHead>
+              <TableHead>Date</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item) => {
+              const canRecover =
+                item.recoverable_quantity > 0 && !item.blocked_by_pending_transfer;
+              const variantLabel =
+                item.inventory_item?.name ||
+                (item.product_variant
+                  ? `${item.product_variant.color} / ${item.product_variant.size}`
+                  : `Variant ${item.product_variant_id}`);
+
+              return (
+                <TableRow key={item.ID}>
+                  <TableCell>
+                    <Checkbox
+                      checked={selectedIds.has(item.ID)}
+                      disabled={!canRecover}
+                      onCheckedChange={() => onToggleItem(item.ID)}
+                      aria-label={`Select ${variantLabel}`}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    {item.franchise?.name || `Franchise ${item.franchise_id}`}
+                  </TableCell>
+                  <TableCell>
+                    <div className="font-medium">{variantLabel}</div>
+                    {item.product_variant?.qr_code ? (
+                      <div className="font-mono text-xs text-muted-foreground">
+                        {item.product_variant.qr_code}
+                      </div>
+                    ) : null}
+                  </TableCell>
+                  <TableCell>{item.broken_quantity}</TableCell>
+                  <TableCell>{item.recovered_quantity}</TableCell>
+                  <TableCell className="font-semibold">{item.recoverable_quantity}</TableCell>
+                  <TableCell>{item.inventory_item?.quantity ?? "-"}</TableCell>
+                  <TableCell>{item.inventory_item?.broken_count ?? "-"}</TableCell>
+                  <TableCell>{getStatusBadge(item.status)}</TableCell>
+                  <TableCell className="max-w-xs truncate">{item.reason || "-"}</TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {item.created_at
+                      ? format(new Date(item.created_at), "MMM dd, yyyy HH:mm")
+                      : "N/A"}
+                  </TableCell>
+                  <TableCell>
+                    {item.blocked_by_pending_transfer ? (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="flex items-center gap-1 text-amber-600 text-sm">
+                              <AlertTriangle className="h-4 w-4" />
+                              Pending transfer
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>
+                              Reject the pending transfer first on the{" "}
+                              <Link to={transfersPath} className="underline">
+                                transfers page
+                              </Link>
+                              .
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={!canRecover}
+                        onClick={() => openRecoverDialog(item)}
+                      >
+                        <RotateCcw className="h-4 w-4 mr-1" />
+                        Recover
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {pagination && totalPages > 1 && onPageChange ? (
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (currentPage > 1) onPageChange(currentPage - 1);
+                }}
+                className={currentPage <= 1 ? "pointer-events-none opacity-50" : undefined}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => i + 1)
+              .filter((p) => {
+                if (totalPages <= 7) return true;
+                return p === 1 || p === totalPages || Math.abs(p - currentPage) <= 1;
+              })
+              .map((p, idx, arr) => {
+                const prev = arr[idx - 1];
+                const showEllipsis = prev !== undefined && p - prev > 1;
+                return (
+                  <span key={p} className="flex items-center">
+                    {showEllipsis ? (
+                      <PaginationItem>
+                        <span className="px-2 text-muted-foreground">…</span>
+                      </PaginationItem>
+                    ) : null}
+                    <PaginationItem>
+                      <PaginationLink
+                        href="#"
+                        isActive={p === currentPage}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          onPageChange(p);
+                        }}
+                      >
+                        {p}
+                      </PaginationLink>
+                    </PaginationItem>
+                  </span>
+                );
+              })}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (currentPage < totalPages) onPageChange(currentPage + 1);
+                }}
+                className={currentPage >= totalPages ? "pointer-events-none opacity-50" : undefined}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      ) : null}
+
+      <RecoverBrokenItemDialog
+        item={selectedItem}
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setSelectedItem(null);
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/feature-specific/broken-items/recover-broken-item-dialog.tsx
+++ b/src/components/feature-specific/broken-items/recover-broken-item-dialog.tsx
@@ -1,0 +1,154 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { BrokenItemListItem } from "@/models/data/broken-item.model";
+import { recoverBrokenItem } from "@/services/broken-items-service";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+interface RecoverBrokenItemDialogProps {
+  item: BrokenItemListItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function RecoverBrokenItemDialog({
+  item,
+  open,
+  onOpenChange,
+}: RecoverBrokenItemDialogProps) {
+  const [quantity, setQuantity] = useState(1);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const recoverableQuantity = item?.recoverable_quantity ?? 0;
+
+  useEffect(() => {
+    if (open && item) {
+      setQuantity(item.recoverable_quantity);
+    }
+  }, [open, item]);
+
+  const { mutate: recoverMutation, isPending } = useMutation({
+    mutationFn: recoverBrokenItem,
+    onSuccess: () => {
+      onOpenChange(false);
+      toast({
+        title: "Item recovered",
+        description: "Declared quantity has been restored to sellable inventory.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["broken-items-declarations"] });
+      queryClient.invalidateQueries({ queryKey: ["broken-items"] });
+      queryClient.invalidateQueries({ queryKey: ["franchise-inventory"] });
+      queryClient.invalidateQueries({ queryKey: ["company-inventory"] });
+      queryClient.invalidateQueries({ queryKey: ["inventory-total-cost"] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Recovery failed",
+        description: error.message || "Something went wrong",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleRecover = () => {
+    if (!item) return;
+    if (quantity < 1 || quantity > recoverableQuantity) {
+      toast({
+        title: "Invalid quantity",
+        description: `Enter a value between 1 and ${recoverableQuantity}.`,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    recoverMutation({
+      inventory_item_id: item.inventory_item_id,
+      product_variant_id: item.product_variant_id,
+      recovered_quantity: quantity,
+    });
+  };
+
+  if (!item) return null;
+
+  const variantLabel =
+    item.inventory_item?.name ||
+    (item.product_variant
+      ? `${item.product_variant.color} / ${item.product_variant.size}`
+      : `Variant ${item.product_variant_id}`);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Recover declared quantity</DialogTitle>
+          <DialogDescription>
+            Restore units from broken declarations back to sellable inventory for{" "}
+            <span className="font-medium">{variantLabel}</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <Label className="text-muted-foreground">Declared</Label>
+              <p className="font-medium">{item.broken_quantity}</p>
+            </div>
+            <div>
+              <Label className="text-muted-foreground">Already recovered</Label>
+              <p className="font-medium">{item.recovered_quantity}</p>
+            </div>
+            <div>
+              <Label className="text-muted-foreground">Recoverable</Label>
+              <p className="font-medium">{recoverableQuantity}</p>
+            </div>
+            <div>
+              <Label className="text-muted-foreground">Current sellable qty</Label>
+              <p className="font-medium">{item.inventory_item?.quantity ?? "-"}</p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="recover-quantity">Quantity to recover</Label>
+            <div className="flex gap-2">
+              <Input
+                id="recover-quantity"
+                type="number"
+                min={1}
+                max={recoverableQuantity}
+                value={quantity}
+                onChange={(e) => setQuantity(Number(e.target.value))}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setQuantity(recoverableQuantity)}
+              >
+                Recover all
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleRecover} disabled={isPending || recoverableQuantity < 1}>
+            {isPending ? "Recovering..." : "Recover"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature-specific/broken-items/transfers-list.tsx
+++ b/src/components/feature-specific/broken-items/transfers-list.tsx
@@ -9,7 +9,15 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Eye, Check, X } from "lucide-react";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { Eye, Check } from "lucide-react";
 import { useState } from "react";
 import ApproveTransferDialog from "./approve-transfer-dialog";
 import { format } from "date-fns";
@@ -17,9 +25,21 @@ import { format } from "date-fns";
 interface TransfersListProps {
   transfers: BrokenItemTransfer[];
   isLoading?: boolean;
+  pagination?: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+  };
+  onPageChange?: (page: number) => void;
 }
 
-export function TransfersList({ transfers, isLoading }: TransfersListProps) {
+export function TransfersList({
+  transfers,
+  isLoading,
+  pagination,
+  onPageChange,
+}: TransfersListProps) {
   const [selectedTransfer, setSelectedTransfer] = useState<BrokenItemTransfer | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -56,6 +76,9 @@ export function TransfersList({ transfers, isLoading }: TransfersListProps) {
       </div>
     );
   }
+
+  const currentPage = pagination?.page ?? 1;
+  const totalPages = pagination?.total_pages ?? 1;
 
   return (
     <>
@@ -97,7 +120,7 @@ export function TransfersList({ transfers, isLoading }: TransfersListProps) {
                   {transfer.requested_by?.full_name || transfer.requested_by?.email || `Admin ${transfer.requested_by_id}`}
                 </TableCell>
                 <TableCell className="text-sm text-muted-foreground">
-                  {transfer.created_at 
+                  {transfer.created_at
                     ? format(new Date(transfer.created_at), "MMM dd, yyyy HH:mm")
                     : "N/A"}
                 </TableCell>
@@ -131,7 +154,68 @@ export function TransfersList({ transfers, isLoading }: TransfersListProps) {
         </Table>
       </div>
 
-      {selectedTransfer && (
+      {pagination && totalPages > 1 && onPageChange ? (
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (currentPage > 1) onPageChange(currentPage - 1);
+                }}
+                className={currentPage <= 1 ? "pointer-events-none opacity-50" : undefined}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => i + 1)
+              .filter((p) => {
+                if (totalPages <= 7) return true;
+                return (
+                  p === 1 ||
+                  p === totalPages ||
+                  Math.abs(p - currentPage) <= 1
+                );
+              })
+              .map((p, idx, arr) => {
+                const prev = arr[idx - 1];
+                const showEllipsis = prev !== undefined && p - prev > 1;
+                return (
+                  <span key={p} className="flex items-center">
+                    {showEllipsis ? (
+                      <PaginationItem>
+                        <span className="px-2 text-muted-foreground">…</span>
+                      </PaginationItem>
+                    ) : null}
+                    <PaginationItem>
+                      <PaginationLink
+                        href="#"
+                        isActive={p === currentPage}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          onPageChange(p);
+                        }}
+                      >
+                        {p}
+                      </PaginationLink>
+                    </PaginationItem>
+                  </span>
+                );
+              })}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (currentPage < totalPages) onPageChange(currentPage + 1);
+                }}
+                className={currentPage >= totalPages ? "pointer-events-none opacity-50" : undefined}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      ) : null}
+
+      {selectedTransfer ? (
         <ApproveTransferDialog
           transfer={selectedTransfer}
           open={dialogOpen}
@@ -142,7 +226,7 @@ export function TransfersList({ transfers, isLoading }: TransfersListProps) {
             }
           }}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/src/models/data/broken-item-transfer.model.ts
+++ b/src/models/data/broken-item-transfer.model.ts
@@ -37,3 +37,20 @@ export interface BrokenItemTransferItem {
     broken_item?: BrokenItem;
     quantity: number;
 }
+
+export interface BrokenItemTransferStatusCounts {
+    pending: number;
+    approved: number;
+    rejected: number;
+}
+
+export interface BrokenItemTransferListResponse {
+    transfers: BrokenItemTransfer[];
+    pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        total_pages: number;
+    };
+    status_counts: BrokenItemTransferStatusCounts;
+}

--- a/src/models/data/broken-item.model.ts
+++ b/src/models/data/broken-item.model.ts
@@ -24,3 +24,26 @@ export interface BrokenItem {
     status: string; // "pending", "partially_recovered", "fully_recovered", "lost"
     reason: string;
 }
+
+export interface BrokenItemListItem extends BrokenItem {
+    recoverable_quantity: number;
+    blocked_by_pending_transfer: boolean;
+}
+
+export interface BrokenItemStatusCounts {
+    pending: number;
+    partially_recovered: number;
+    fully_recovered: number;
+    lost: number;
+}
+
+export interface BrokenItemListResponse {
+    items: BrokenItemListItem[];
+    pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        total_pages: number;
+    };
+    status_counts: BrokenItemStatusCounts;
+}

--- a/src/pages/dashboard/company/company-broken-items-declarations-page.tsx
+++ b/src/pages/dashboard/company/company-broken-items-declarations-page.tsx
@@ -1,0 +1,11 @@
+import { RootState } from "@/app/store";
+import BrokenItemsDeclarationsPageBody from "@/components/feature-specific/broken-items/broken-items-declarations-page-body";
+import { useSelector } from "react-redux";
+
+export default function CompanyBrokenItemsDeclarationsPage() {
+  const company = useSelector((state: RootState) => state.company.company);
+
+  if (!company) return null;
+
+  return <BrokenItemsDeclarationsPageBody companyId={company.ID} />;
+}

--- a/src/pages/dashboard/company/company-broken-items-transfers-page.tsx
+++ b/src/pages/dashboard/company/company-broken-items-transfers-page.tsx
@@ -1,117 +1,11 @@
 import { RootState } from "@/app/store";
-import { TransfersList } from "@/components/feature-specific/broken-items/transfers-list";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { getTransferRequests } from "@/services/broken-items-service";
-import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, RefreshCw } from "lucide-react";
+import BrokenItemsTransfersPageBody from "@/components/feature-specific/broken-items/broken-items-transfers-page-body";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
-import { useState } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 export default function CompanyBrokenItemsTransfersPage() {
-  const navigate = useNavigate();
   const company = useSelector((state: RootState) => state.company.company);
-  const [statusFilter, setStatusFilter] = useState<string>("all");
 
   if (!company) return null;
 
-  const { data, isLoading, refetch } = useQuery({
-    queryKey: ["broken-items-transfers", company.ID, statusFilter],
-    queryFn: () => getTransferRequests({
-      company_id: company.ID,
-      ...(statusFilter !== "all" ? { status: statusFilter as "pending" | "approved" | "rejected" } : {}),
-    }),
-    enabled: !!company,
-  });
-
-  const transfers = data?.data || [];
-  const pendingCount = transfers.filter((t) => t.status === "pending").length;
-  const approvedCount = transfers.filter((t) => t.status === "approved").length;
-  const rejectedCount = transfers.filter((t) => t.status === "rejected").length;
-
-  return (
-    <div className="flex flex-col gap-4 p-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold">Broken Items Transfers</h1>
-            <p className="text-muted-foreground">
-              Review and manage broken item transfer requests from franchises
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Filter by status" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Status</SelectItem>
-              <SelectItem value="pending">Pending</SelectItem>
-              <SelectItem value="approved">Approved</SelectItem>
-              <SelectItem value="rejected">Rejected</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button variant="outline" onClick={() => refetch()}>
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Refresh
-          </Button>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Pending</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-2xl font-bold text-yellow-600">
-              {pendingCount}
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Approved</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-2xl font-bold text-green-600">
-              {approvedCount}
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Rejected</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-2xl font-bold text-red-600">
-              {rejectedCount}
-            </CardDescription>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Transfer Requests</CardTitle>
-          <CardDescription>
-            {statusFilter === "all" 
-              ? "All transfer requests" 
-              : `Transfer requests with status: ${statusFilter}`}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <TransfersList transfers={transfers} isLoading={isLoading} />
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <BrokenItemsTransfersPageBody companyId={company.ID} />;
 }

--- a/src/pages/dashboard/company/company-control-panel-page.tsx
+++ b/src/pages/dashboard/company/company-control-panel-page.tsx
@@ -16,6 +16,7 @@ import {
   Package,
   PackageX,
   ReceiptText,
+  RotateCcw,
   ShoppingCart,
   Store,
   Truck,
@@ -226,6 +227,11 @@ const quickMenu: Array<{
     label: "Broken Items Transfers",
     icon: PackageX,
     href: "broken-items-transfers",
+  },
+  {
+    label: "Declared Quantities",
+    icon: RotateCcw,
+    href: "broken-items-declarations",
   },
   {
     label: "Franchise fulfillment",

--- a/src/pages/moderator/dashboard/moderator-broken-items-declarations-page.tsx
+++ b/src/pages/moderator/dashboard/moderator-broken-items-declarations-page.tsx
@@ -1,0 +1,11 @@
+import { RootState } from "@/app/store";
+import BrokenItemsDeclarationsPageBody from "@/components/feature-specific/broken-items/broken-items-declarations-page-body";
+import { useSelector } from "react-redux";
+
+export default function ModeratorBrokenItemsDeclarationsPage() {
+  const company = useSelector((state: RootState) => state.user.company);
+
+  if (!company) return null;
+
+  return <BrokenItemsDeclarationsPageBody companyId={company.ID} />;
+}

--- a/src/pages/moderator/dashboard/moderator-broken-items-transfers-page.tsx
+++ b/src/pages/moderator/dashboard/moderator-broken-items-transfers-page.tsx
@@ -1,117 +1,11 @@
 import { RootState } from "@/app/store";
-import { TransfersList } from "@/components/feature-specific/broken-items/transfers-list";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { getTransferRequests } from "@/services/broken-items-service";
-import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, RefreshCw } from "lucide-react";
+import BrokenItemsTransfersPageBody from "@/components/feature-specific/broken-items/broken-items-transfers-page-body";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
-import { useState } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 export default function ModeratorBrokenItemsTransfersPage() {
-  const navigate = useNavigate();
   const company = useSelector((state: RootState) => state.user.company);
-  const [statusFilter, setStatusFilter] = useState<string>("all");
 
   if (!company) return null;
 
-  const { data, isLoading, refetch } = useQuery({
-    queryKey: ["broken-items-transfers", company.ID, statusFilter],
-    queryFn: () => getTransferRequests({
-      company_id: company.ID,
-      ...(statusFilter !== "all" ? { status: statusFilter as "pending" | "approved" | "rejected" } : {}),
-    }),
-    enabled: !!company,
-  });
-
-  const transfers = data?.data || [];
-  const pendingCount = transfers.filter((t) => t.status === "pending").length;
-  const approvedCount = transfers.filter((t) => t.status === "approved").length;
-  const rejectedCount = transfers.filter((t) => t.status === "rejected").length;
-
-  return (
-    <div className="flex flex-col gap-4 p-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold">Broken Items Transfers</h1>
-            <p className="text-muted-foreground">
-              Review and manage broken item transfer requests from franchises
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Filter by status" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Status</SelectItem>
-              <SelectItem value="pending">Pending</SelectItem>
-              <SelectItem value="approved">Approved</SelectItem>
-              <SelectItem value="rejected">Rejected</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button variant="outline" onClick={() => refetch()}>
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Refresh
-          </Button>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Pending</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-2xl font-bold text-yellow-600">
-              {pendingCount}
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Approved</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-2xl font-bold text-green-600">
-              {approvedCount}
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Rejected</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-2xl font-bold text-red-600">
-              {rejectedCount}
-            </CardDescription>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Transfer Requests</CardTitle>
-          <CardDescription>
-            {statusFilter === "all" 
-              ? "All transfer requests" 
-              : `Transfer requests with status: ${statusFilter}`}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <TransfersList transfers={transfers} isLoading={isLoading} />
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <BrokenItemsTransfersPageBody companyId={company.ID} />;
 }

--- a/src/pages/moderator/dashboard/user-menu-page.tsx
+++ b/src/pages/moderator/dashboard/user-menu-page.tsx
@@ -10,6 +10,7 @@ import {
   Package,
   PackageX,
   ReceiptText,
+  RotateCcw,
   ShoppingCart,
   Store,
   Ticket,
@@ -107,6 +108,11 @@ const quickMenu = [
     label: "Broken Items Transfers",
     icon: PackageX,
     href: "broken-items-transfers",
+  },
+  {
+    label: "Declared Quantities",
+    icon: RotateCcw,
+    href: "broken-items-declarations",
   },
   {
     label: "Franchise fulfillment",

--- a/src/services/broken-items-service.ts
+++ b/src/services/broken-items-service.ts
@@ -1,7 +1,13 @@
 import { baseUrl } from "@/app/constants";
 import { APIResponse } from "@/models/responses/api-response.model";
-import { BrokenItem } from "@/models/data/broken-item.model";
-import { BrokenItemTransfer } from "@/models/data/broken-item-transfer.model";
+import {
+    BrokenItem,
+    BrokenItemListResponse,
+} from "@/models/data/broken-item.model";
+import {
+    BrokenItemTransfer,
+    BrokenItemTransferListResponse,
+} from "@/models/data/broken-item-transfer.model";
 
 export interface RecordBrokenItemsRequest {
     inventory_id: number;
@@ -28,6 +34,25 @@ export interface GetTransferRequestsParams {
     status?: "pending" | "approved" | "rejected";
     company_id?: number;
     franchise_id?: number;
+    page?: number;
+    limit?: number;
+}
+
+export interface GetBrokenItemsParams {
+    company_id?: number;
+    franchise_id?: number;
+    inventory_id?: number;
+    location_type?: string;
+    status?: string;
+    page?: number;
+    limit?: number;
+    recoverable_only?: boolean;
+}
+
+export interface RecoverBrokenItemRequest {
+    inventory_item_id: number;
+    product_variant_id: number;
+    recovered_quantity: number;
 }
 
 export const recordBrokenItems = async (
@@ -91,13 +116,70 @@ export const approveTransfer = async (
     return await response.json();
 };
 
+export const getBrokenItems = async (
+    params?: GetBrokenItemsParams
+): Promise<APIResponse<BrokenItem[] | BrokenItemListResponse>> => {
+    const queryParams = new URLSearchParams();
+    if (params?.company_id) queryParams.append("company_id", params.company_id.toString());
+    if (params?.franchise_id) queryParams.append("franchise_id", params.franchise_id.toString());
+    if (params?.inventory_id) queryParams.append("inventory_id", params.inventory_id.toString());
+    if (params?.location_type) queryParams.append("location_type", params.location_type);
+    if (params?.status) queryParams.append("status", params.status);
+    if (params?.page) queryParams.append("page", params.page.toString());
+    if (params?.limit) queryParams.append("limit", params.limit.toString());
+    if (params?.recoverable_only) queryParams.append("recoverable_only", "true");
+
+    const url = `${baseUrl}/broken-items${queryParams.toString() ? `?${queryParams.toString()}` : ""}`;
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to fetch broken items.");
+    }
+
+    return await response.json();
+};
+
+export const recoverBrokenItem = async (
+    data: RecoverBrokenItemRequest
+): Promise<APIResponse<BrokenItem>> => {
+    const response = await fetch(`${baseUrl}/broken-items/recover`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify({
+            inventory_item_id: data.inventory_item_id,
+            product_variant_id: data.product_variant_id,
+            recovered_quantity: data.recovered_quantity,
+        }),
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to recover broken item.");
+    }
+
+    return await response.json();
+};
+
 export const getTransferRequests = async (
     params?: GetTransferRequestsParams
-): Promise<APIResponse<BrokenItemTransfer[]>> => {
+): Promise<APIResponse<BrokenItemTransferListResponse>> => {
     const queryParams = new URLSearchParams();
     if (params?.status) queryParams.append("status", params.status);
     if (params?.company_id) queryParams.append("company_id", params.company_id.toString());
     if (params?.franchise_id) queryParams.append("franchise_id", params.franchise_id.toString());
+    if (params?.page) queryParams.append("page", params.page.toString());
+    if (params?.limit) queryParams.append("limit", params.limit.toString());
 
     const url = `${baseUrl}/broken-items/transfers${queryParams.toString() ? `?${queryParams.toString()}` : ""}`;
 


### PR DESCRIPTION

- Introduced new pages and components for managing broken item declarations and transfers, enhancing the user experience for both company and moderator roles.
- Implemented `BrokenItemsDeclarationsPageBody` and `BrokenItemsTransfersPageBody` components to handle the respective functionalities.
- Added routing for broken item declarations and transfers in the application.
- Enhanced data fetching and state management for broken items, including pagination and filtering options.
- Updated UI components to support new features, including dialogs for recovering broken items and managing transfer requests.