### PR TITLE
feat(franchise-alerts): add snooze functionality for pending order alerts

### DIFF
--- a/src/components/feature-specific/ship-from-store/franchise-pending-order-alert-dialog.tsx
+++ b/src/components/feature-specific/ship-from-store/franchise-pending-order-alert-dialog.tsx
@@ -27,6 +27,7 @@ import {
   Phone,
   Printer,
   ShoppingCart,
+  Timer,
   User,
 } from "lucide-react";
 import { useState } from "react";
@@ -35,12 +36,14 @@ interface Props {
   order: WooOrder | null;
   remainingCount: number;
   onAcknowledged: (orderId: number) => void;
+  onSnooze: () => void;
 }
 
 export default function FranchisePendingOrderAlertDialog({
   order,
   remainingCount,
   onAcknowledged,
+  onSnooze,
 }: Props) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -136,8 +139,8 @@ export default function FranchisePendingOrderAlertDialog({
                     New ship-from-store order #{order.number || order.id}
                   </DialogTitle>
                   <DialogDescription>
-                    Update the franchise status to continue. This alert stays open
-                    until the order is marked packed or not available.
+                    Update the franchise status to continue, or snooze this alert
+                    for 10 minutes to keep working in the portal.
                     {remainingCount > 1
                       ? ` (${remainingCount} pending orders)`
                       : null}
@@ -282,22 +285,39 @@ export default function FranchisePendingOrderAlertDialog({
                 </div>
 
                 <DialogFooter className="gap-2 sm:justify-between">
-                  <Button
-                    variant="outline"
-                    disabled={
-                      !order.has_shipping_label ||
-                      labelLoading ||
-                      mutation.isPending
-                    }
-                    onClick={() => void handlePrintLabel()}
-                  >
-                    {labelLoading ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                      <Printer className="mr-2 h-4 w-4" />
-                    )}
-                    Print label
-                  </Button>
+                  <div className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-2">
+                    <Button
+                      variant="outline"
+                      disabled={
+                        !order.has_shipping_label ||
+                        labelLoading ||
+                        mutation.isPending
+                      }
+                      onClick={() => void handlePrintLabel()}
+                    >
+                      {labelLoading ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Printer className="mr-2 h-4 w-4" />
+                      )}
+                      Print label
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      disabled={mutation.isPending}
+                      onClick={() => {
+                        onSnooze();
+                        toast({
+                          title: "Reminder set",
+                          description:
+                            "This alert will come back in 10 minutes.",
+                        });
+                      }}
+                    >
+                      <Timer className="mr-2 h-4 w-4" />
+                      Remind me in 10 minutes
+                    </Button>
+                  </div>
                   <div className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-2">
                     <Button
                       variant="destructive"

--- a/src/components/feature-specific/ship-from-store/franchise-pending-order-alerts-host.tsx
+++ b/src/components/feature-specific/ship-from-store/franchise-pending-order-alerts-host.tsx
@@ -13,7 +13,7 @@ export default function FranchisePendingOrderAlertsHost() {
     (state: RootState) => state.franchise.franchise
   );
   const enabled = !!franchise?.require_order_alert;
-  const { current, queueLength, dismissOrder } =
+  const { current, queueLength, dismissOrder, snooze } =
     useFranchisePendingOrderAlerts(enabled ? franchise?.ID : undefined);
 
   if (!enabled) {
@@ -25,6 +25,7 @@ export default function FranchisePendingOrderAlertsHost() {
       order={current}
       remainingCount={queueLength}
       onAcknowledged={dismissOrder}
+      onSnooze={() => snooze()}
     />
   );
 }

--- a/src/hooks/use-franchise-pending-order-alerts.ts
+++ b/src/hooks/use-franchise-pending-order-alerts.ts
@@ -5,6 +5,27 @@ import {
 import type { WooOrder } from "@/models/data/woo-order.model";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const SNOOZE_MS = 10 * 60 * 1000;
+
+function snoozeStorageKey(franchiseId: number) {
+  return `franchise-order-alert-snooze-until:${franchiseId}`;
+}
+
+function readSnoozeUntil(franchiseId: number): number | null {
+  try {
+    const raw = localStorage.getItem(snoozeStorageKey(franchiseId));
+    if (!raw) return null;
+    const until = Number(raw);
+    if (!Number.isFinite(until) || until <= Date.now()) {
+      localStorage.removeItem(snoozeStorageKey(franchiseId));
+      return null;
+    }
+    return until;
+  } catch {
+    return null;
+  }
+}
+
 interface FranchiseOrderPendingEvent {
   event: string;
   data: WooOrder;
@@ -48,11 +69,16 @@ async function fetchPendingOrders(): Promise<WooOrder[]> {
 /**
  * Keeps a FIFO queue of pending ship-from-store orders for the franchise portal.
  * Catch-up on connect/reconnect + live WS `franchise_order_pending` events.
+ * Supports a temporary snooze that hides the alert UI without acknowledging orders.
  */
 export function useFranchisePendingOrderAlerts(franchiseId: number | undefined) {
   const [queue, setQueue] = useState<WooOrder[]>([]);
+  const [snoozeUntil, setSnoozeUntil] = useState<number | null>(() =>
+    franchiseId && franchiseId > 0 ? readSnoozeUntil(franchiseId) : null
+  );
   const shouldReconnect = useRef(true);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const snoozeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
 
   const enqueue = useCallback((orders: WooOrder[]) => {
@@ -62,6 +88,63 @@ export function useFranchisePendingOrderAlerts(franchiseId: number | undefined) 
   const dismissOrder = useCallback((orderId: number) => {
     setQueue((prev) => prev.filter((o) => o.id !== orderId));
   }, []);
+
+  const clearSnooze = useCallback(() => {
+    if (franchiseId && franchiseId > 0) {
+      try {
+        localStorage.removeItem(snoozeStorageKey(franchiseId));
+      } catch {
+        // ignore storage errors
+      }
+    }
+    setSnoozeUntil(null);
+  }, [franchiseId]);
+
+  const snooze = useCallback(
+    (durationMs: number = SNOOZE_MS) => {
+      if (!franchiseId || franchiseId <= 0) return;
+      const until = Date.now() + durationMs;
+      try {
+        localStorage.setItem(snoozeStorageKey(franchiseId), String(until));
+      } catch {
+        // ignore storage errors; in-memory snooze still applies
+      }
+      setSnoozeUntil(until);
+    },
+    [franchiseId]
+  );
+
+  // Rehydrate / clear snooze when franchise changes
+  useEffect(() => {
+    if (!franchiseId || franchiseId <= 0) {
+      setSnoozeUntil(null);
+      return;
+    }
+    setSnoozeUntil(readSnoozeUntil(franchiseId));
+  }, [franchiseId]);
+
+  // Wake up when snooze expires
+  useEffect(() => {
+    if (snoozeTimeoutRef.current) {
+      clearTimeout(snoozeTimeoutRef.current);
+      snoozeTimeoutRef.current = null;
+    }
+    if (snoozeUntil == null) return;
+    const remaining = snoozeUntil - Date.now();
+    if (remaining <= 0) {
+      clearSnooze();
+      return;
+    }
+    snoozeTimeoutRef.current = setTimeout(() => {
+      clearSnooze();
+    }, remaining);
+    return () => {
+      if (snoozeTimeoutRef.current) {
+        clearTimeout(snoozeTimeoutRef.current);
+        snoozeTimeoutRef.current = null;
+      }
+    };
+  }, [snoozeUntil, clearSnooze]);
 
   const loadCatchUp = useCallback(async () => {
     try {
@@ -143,7 +226,14 @@ export function useFranchisePendingOrderAlerts(franchiseId: number | undefined) 
     };
   }, [franchiseId, enqueue, loadCatchUp]);
 
-  const current = queue[0] ?? null;
+  const isSnoozed = snoozeUntil != null && snoozeUntil > Date.now();
+  const current = isSnoozed ? null : queue[0] ?? null;
 
-  return { current, queueLength: queue.length, dismissOrder };
+  return {
+    current,
+    queueLength: queue.length,
+    dismissOrder,
+    snooze,
+    isSnoozed,
+  };
 }


### PR DESCRIPTION


- Introduced a snooze feature that allows users to temporarily hide pending order alerts for 10 minutes, enhancing user experience and flexibility in managing alerts.
- Updated the FranchisePendingOrderAlertDialog to include a new button for setting reminders, along with toast notifications for user feedback.
- Enhanced the useFranchisePendingOrderAlerts hook to manage snooze state and expiration, ensuring alerts reappear after the snooze duration.
- Modified the FranchisePendingOrderAlertsHost to integrate the new snooze functionality, improving overall alert management.