### PR TITLE
feat(company-missing-variants): integrate franchise inventory details into missing variants columns and dialogs

### DIFF
--- a/src/components/feature-specific/company-missing-variants/company-missing-variants-columns.tsx
+++ b/src/components/feature-specific/company-missing-variants/company-missing-variants-columns.tsx
@@ -1,3 +1,4 @@
+import TransactionsLogDialog from "@/components/feature-specific/company-warehouse/transactions-log-dialog";
 import { Button } from "@/components/ui/button";
 import { MissingVariantRequestResponse } from "@/models/data/missing-variant.model";
 import { ColumnDef } from "@tanstack/react-table";
@@ -68,6 +69,40 @@ export const createCompanyMissingVariantsColumns = ({
     },
   },
   {
+    accessorKey: "franchise_inventory_quantity",
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Franchise stock
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const qty = row.original.franchise_inventory_quantity ?? 0;
+      const itemId = row.original.franchise_inventory_item_id;
+      if (!itemId) {
+        return <span className="text-muted-foreground">{qty}</span>;
+      }
+      return (
+        <TransactionsLogDialog
+          inventoryItemId={itemId}
+          trigger={
+            <button
+              type="button"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              {qty}
+            </button>
+          }
+        />
+      );
+    },
+  },
+  {
     accessorKey: "franchise_name",
     header: ({ column }) => {
       return (
@@ -133,7 +168,7 @@ export const createCompanyMissingVariantsColumns = ({
     cell: ({ row }) => {
       const request = row.original;
       const canCancel = request.status === "pending";
-      
+
       return (
         <div className="flex items-center gap-2">
           {canCancel && onCancel && (

--- a/src/components/feature-specific/company-missing-variants/create-exit-bill-dialog.tsx
+++ b/src/components/feature-specific/company-missing-variants/create-exit-bill-dialog.tsx
@@ -1,4 +1,5 @@
 import { RootState } from "@/app/store";
+import TransactionsLogDialog from "@/components/feature-specific/company-warehouse/transactions-log-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -310,9 +311,31 @@ export default function CreateExitBillDialog({
                                   </Badge>
                                 )}
                               </div>
-                              <Badge variant="outline" className="text-xs">
-                                Original: {request.requested_quantity}
-                              </Badge>
+                              <div className="flex items-center gap-2">
+                                <Badge variant="outline" className="text-xs">
+                                  Franchise stock:{" "}
+                                  {request.franchise_inventory_item_id ? (
+                                    <TransactionsLogDialog
+                                      inventoryItemId={request.franchise_inventory_item_id}
+                                      trigger={
+                                        <button
+                                          type="button"
+                                          className="ml-1 font-semibold text-primary underline-offset-2 hover:underline"
+                                        >
+                                          {request.franchise_inventory_quantity ?? 0}
+                                        </button>
+                                      }
+                                    />
+                                  ) : (
+                                    <span className="ml-1">
+                                      {request.franchise_inventory_quantity ?? 0}
+                                    </span>
+                                  )}
+                                </Badge>
+                                <Badge variant="outline" className="text-xs">
+                                  Original: {request.requested_quantity}
+                                </Badge>
+                              </div>
                             </div>
                             <FormField
                               control={form.control}

--- a/src/components/feature-specific/company-warehouse/transactions-log-dialog.tsx
+++ b/src/components/feature-specific/company-warehouse/transactions-log-dialog.tsx
@@ -21,13 +21,15 @@ import {
 import { getInventoryItemTransactionLogs } from "@/services/inventory-service";
 import { useQuery } from "@tanstack/react-query";
 import { History, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 
 interface Props {
   inventoryItemId: number;
+  /** Custom clickable trigger; defaults to a History icon button */
+  trigger?: ReactNode;
 }
 
-export default function ({ inventoryItemId }: Props) {
+export default function ({ inventoryItemId, trigger }: Props) {
   const [open, setOpen] = useState(false);
   const [referenceOpen, setReferenceOpen] = useState(false);
   const [selectedReference, setSelectedReference] = useState<{
@@ -51,10 +53,12 @@ export default function ({ inventoryItemId }: Props) {
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger>
-          <Button variant={"ghost"}>
-            <History />
-          </Button>
+        <DialogTrigger asChild>
+          {trigger ?? (
+            <Button variant={"ghost"}>
+              <History />
+            </Button>
+          )}
         </DialogTrigger>
         <DialogContent className="w-fit ">
           <DialogHeader>

--- a/src/models/data/missing-variant.model.ts
+++ b/src/models/data/missing-variant.model.ts
@@ -35,6 +35,10 @@ export interface MissingVariantRequestResponse {
   product_variant_color: string;
   product_variant_size: number;
   requested_quantity: number;
+  /** Current stock of this variant in the franchise inventory */
+  franchise_inventory_quantity: number;
+  /** Franchise inventory item id (for transaction logs); omitted if no item exists */
+  franchise_inventory_item_id?: number;
   status: MissingVariantStatus;
   comment?: string;
   created_at: string;


### PR DESCRIPTION

- Added a new column for franchise stock in the company missing variants table, allowing users to view and interact with inventory quantities.
- Integrated TransactionsLogDialog to display transaction logs for franchise inventory items, enhancing visibility into stock levels.
- Updated CreateExitBillDialog to show franchise stock alongside original requested quantities, improving clarity for users.
- Enhanced the TransactionsLogDialog component to accept a custom trigger, providing flexibility in how inventory details are displayed.