### PR TITLE
feat(franchise-fulfillment): implement caching for shipping label status updates

### DIFF
--- a/src/components/feature-specific/ship-from-store/company-franchise-fulfillment-orders-columns.tsx
+++ b/src/components/feature-specific/ship-from-store/company-franchise-fulfillment-orders-columns.tsx
@@ -9,7 +9,10 @@ import {
   WooOrder,
   isFranchiseOrderStatus,
 } from "@/models/data/woo-order.model";
-import { uploadWooOrderShippingLabel } from "@/services/franchise-fulfillment-service";
+import {
+  markOrderHasShippingLabelInCache,
+  uploadWooOrderShippingLabel,
+} from "@/services/franchise-fulfillment-service";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { Eye, FileSearch, Printer, Upload } from "lucide-react";
@@ -106,9 +109,7 @@ function UploadLabelCell({
         title: "Label uploaded",
         description: `Shipping label saved for order #${order.number || order.id}.`,
       });
-      queryClient.invalidateQueries({
-        queryKey: ["company-franchise-fulfillment-orders"],
-      });
+      markOrderHasShippingLabelInCache(queryClient, order.id);
     },
     onError: (error: Error) => {
       toast({

--- a/src/components/feature-specific/ship-from-store/shipping-label-preview-dialog.tsx
+++ b/src/components/feature-specific/ship-from-store/shipping-label-preview-dialog.tsx
@@ -10,6 +10,7 @@ import { useToast } from "@/hooks/use-toast";
 import { WooOrder } from "@/models/data/woo-order.model";
 import {
   getCompanyWooOrderShippingLabelUrl,
+  markOrderHasShippingLabelInCache,
   uploadWooOrderShippingLabel,
 } from "@/services/franchise-fulfillment-service";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -50,9 +51,7 @@ export function ShippingLabelPreviewDialog({
         title: "Label replaced",
         description: `Shipping label updated for order #${order.number || order.id}.`,
       });
-      await queryClient.invalidateQueries({
-        queryKey: ["company-franchise-fulfillment-orders"],
-      });
+      markOrderHasShippingLabelInCache(queryClient, order.id);
       await queryClient.invalidateQueries({
         queryKey: ["company-shipping-label-url", order.id, companyId],
       });

--- a/src/services/franchise-fulfillment-service.ts
+++ b/src/services/franchise-fulfillment-service.ts
@@ -3,6 +3,26 @@ import { FranchiseCommissionsResponse } from "@/models/data/franchise-commission
 import { ShipFromStore } from "@/models/data/ship-from-store.model";
 import { WooOrder } from "@/models/data/woo-order.model";
 import { APIResponse } from "@/models/responses/api-response.model";
+import { QueryClient } from "@tanstack/react-query";
+
+/** Patch has_shipping_label in-place so the orders table does not refetch/reorder. */
+export function markOrderHasShippingLabelInCache(
+  queryClient: QueryClient,
+  orderId: number
+) {
+  queryClient.setQueriesData<APIResponse<WooOrder[]>>(
+    { queryKey: ["company-franchise-fulfillment-orders"] },
+    (old) => {
+      if (!old?.data) return old;
+      return {
+        ...old,
+        data: old.data.map((order) =>
+          order.id === orderId ? { ...order, has_shipping_label: true } : order
+        ),
+      };
+    }
+  );
+}
 
 const authHeaders = () => ({
   "Content-Type": "application/json",


### PR DESCRIPTION


- Added a new function, markOrderHasShippingLabelInCache, to update the shipping label status in the query cache without refetching data, improving performance.
- Updated UploadLabelCell and ShippingLabelPreviewDialog components to utilize the new caching function, enhancing user experience by reducing unnecessary queries.